### PR TITLE
Fix walk force-advance bug and update dependencies

### DIFF
--- a/.claude/hooks/context-recovery.sh
+++ b/.claude/hooks/context-recovery.sh
@@ -27,7 +27,7 @@ cat <<'BANNER'
 ║  PAST FAILURES (why this exists):                            ║
 ║  - isPitch was false for outs/hits → 30% pitch undercount   ║
 ║  - HBP force-advance cleared non-forced runners              ║
-║  - Walk handler STILL has same bug (AB-004) — don't trust it║
+║  - Walk handler was FIXED (AB-004) — uses force-chain now   ║
 ║  - Scoring mode split was re-planned by a session that       ║
 ║    didn't know it was already done                           ║
 ╠══════════════════════════════════════════════════════════════╣

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -13,7 +13,7 @@
 - **Node.js:** v25.6.1 at `/opt/homebrew/bin/node`
 - **PATH prefix:** `export PATH="/opt/homebrew/bin:/usr/bin:$PATH"` (required before npm commands)
 - **Dev server:** Vite on port 5173 (`npm run dev`)
-- **Tests:** Jest (`npm test`) — 4 suites, 32 tests
+- **Tests:** Jest (`npm test`) — 5 suites, 42 tests
 
 ## Routes
 
@@ -90,7 +90,7 @@
 
 ## Known Bugs
 
-- **Walk force-advance bug (pre-existing):** Walk handler in `handleBall` uses simplified runner logic that incorrectly clears non-forced runners (e.g., runner on 2nd with empty 1st gets removed). Not yet fixed — none of the test data triggers it. The HBP handler has the correct force-chain logic.
+- ~~Walk force-advance bug~~ **FIXED** — Walk handler now uses the same force-chain logic as HBP. Regression tests in `walkForceAdvance.test.js`.
 - **Logo uploads disabled:** Cloud Function for logo processing is incomplete.
 
 ## Known Limitations

--- a/docs/as-built.md
+++ b/docs/as-built.md
@@ -66,7 +66,7 @@ if (was.first) {
 state.runners.first = true;
 ```
 
-**Known bug:** The walk handler in `handleBall` (ManualScoreController) still uses the OLD simplified logic. It has the same bug but none of our test data triggers it. Fix it when we next touch `handleBall`.
+**Fixed:** The walk handler in `handleBall` was updated with the same force-chain logic. Regression tests added in `walkForceAdvance.test.js` covering all 8 base-state combinations.
 
 **Why it matters:** Force-advance logic is subtle. A walk/HBP with bases loaded scores a run, but a walk/HBP with runners on 1st and 3rd only (no 2nd) should NOT move the runner from 3rd. The chain only pushes runners who are forced.
 

--- a/src/__tests__/walkForceAdvance.test.js
+++ b/src/__tests__/walkForceAdvance.test.js
@@ -1,0 +1,112 @@
+/**
+ * Walk force-advance tests (AB-004 regression)
+ *
+ * The old walk handler used simplified logic:
+ *   updated.third = runners.second
+ *   updated.second = runners.first
+ *   updated.first = true
+ *
+ * This incorrectly cleared non-forced runners. For example:
+ * - Runner on 2nd only → walk should put batter on 1st, leave 2nd alone
+ *   Old code: updated.third = false (was.second=true), updated.second = false (was.first=false)
+ *   Result: runner on 2nd vanishes!
+ *
+ * The fix uses force-chain logic (same as HBP): only advance runners
+ * in a continuous chain from 1st base.
+ */
+
+import { createGameState, applyAction } from "../utils/scoringEngine";
+
+function walkBatter(state) {
+  // 4 balls = walk
+  applyAction(state, "ball");
+  applyAction(state, "ball");
+  applyAction(state, "ball");
+  applyAction(state, "ball");
+}
+
+describe("Walk force-advance (AB-004)", () => {
+  let game;
+
+  beforeEach(() => {
+    game = createGameState("Home", "Away");
+  });
+
+  test("bases empty → batter walks to 1st", () => {
+    walkBatter(game);
+    expect(game.runners).toEqual({ first: true, second: false, third: false });
+    expect(game.awayScore).toBe(0);
+  });
+
+  test("runner on 1st → batter to 1st, runner forced to 2nd", () => {
+    game.runners.first = true;
+    walkBatter(game);
+    expect(game.runners).toEqual({ first: true, second: true, third: false });
+    expect(game.awayScore).toBe(0);
+  });
+
+  test("runner on 2nd only → batter to 1st, runner stays on 2nd (NOT forced)", () => {
+    // This is the exact bug scenario from AB-004
+    game.runners.second = true;
+    walkBatter(game);
+    expect(game.runners).toEqual({ first: true, second: true, third: false });
+    expect(game.awayScore).toBe(0);
+  });
+
+  test("runner on 3rd only → batter to 1st, runner stays on 3rd (NOT forced)", () => {
+    game.runners.third = true;
+    walkBatter(game);
+    expect(game.runners).toEqual({ first: true, second: false, third: true });
+    expect(game.awayScore).toBe(0);
+  });
+
+  test("runners on 1st and 2nd → both forced, batter to 1st", () => {
+    game.runners.first = true;
+    game.runners.second = true;
+    walkBatter(game);
+    expect(game.runners).toEqual({ first: true, second: true, third: true });
+    expect(game.awayScore).toBe(0);
+  });
+
+  test("runners on 1st and 3rd → 1st forced to 2nd, 3rd stays (no force)", () => {
+    game.runners.first = true;
+    game.runners.third = true;
+    walkBatter(game);
+    expect(game.runners).toEqual({ first: true, second: true, third: true });
+    expect(game.awayScore).toBe(0);
+  });
+
+  test("runners on 2nd and 3rd → neither forced, batter to 1st", () => {
+    game.runners.second = true;
+    game.runners.third = true;
+    walkBatter(game);
+    expect(game.runners).toEqual({ first: true, second: true, third: true });
+    expect(game.awayScore).toBe(0);
+  });
+
+  test("bases loaded → all forced, runner from 3rd scores", () => {
+    game.runners.first = true;
+    game.runners.second = true;
+    game.runners.third = true;
+    walkBatter(game);
+    expect(game.runners).toEqual({ first: true, second: true, third: true });
+    expect(game.awayScore).toBe(1);
+  });
+
+  test("bases loaded walk scores correct team (home batting)", () => {
+    game.isTop = false; // home batting
+    game.runners.first = true;
+    game.runners.second = true;
+    game.runners.third = true;
+    walkBatter(game);
+    expect(game.homeScore).toBe(1);
+    expect(game.awayScore).toBe(0);
+  });
+
+  test("walk resets count to 0-0", () => {
+    game.strikes = 2; // full count scenario
+    walkBatter(game);
+    expect(game.balls).toBe(0);
+    expect(game.strikes).toBe(0);
+  });
+});

--- a/src/components/ManualScoreController.jsx
+++ b/src/components/ManualScoreController.jsx
@@ -205,7 +205,25 @@ const ManualScoreController = ({ gameId }) => {
     saveSnapshot();
     const newBalls = balls + 1;
     if (newBalls >= 4) {
-      const runsScored = runners.third ? 1 : 0;
+      // Force-advance: only runners in continuous chain from 1st (same as HBP, AB-004)
+      const was = { ...runners };
+      let runsScored = 0;
+      if (was.first) {
+        if (was.second) {
+          if (was.third) {
+            addRun();
+            runsScored++;
+          }
+        }
+      }
+      const updated = { ...runners };
+      if (was.first) {
+        if (was.second) {
+          updated.third = true;
+        }
+        updated.second = true;
+      }
+      updated.first = true;
       recordEvent(
         {
           type: "walk",
@@ -217,11 +235,6 @@ const ManualScoreController = ({ gameId }) => {
         getGameState()
       );
       flashHighlight("Walk");
-      const updated = { ...runners };
-      if (runners.third) addRun();
-      updated.third = runners.second;
-      updated.second = runners.first;
-      updated.first = true;
       setRunners(updated);
       setBalls(0);
       setStrikes(0);

--- a/src/utils/scoringEngine.js
+++ b/src/utils/scoringEngine.js
@@ -80,11 +80,19 @@ export function applyAction(state, action) {
     case "ball": {
       const newBalls = state.balls + 1;
       if (newBalls >= 4) {
-        // Walk
-        const runsScored = state.runners.third ? 1 : 0;
-        if (state.runners.third) addRun(state);
-        state.runners.third = state.runners.second;
-        state.runners.second = state.runners.first;
+        // Walk — force-advance runners in continuous chain from 1st (same as HBP, AB-004)
+        const was = { ...state.runners };
+        let runsScored = 0;
+        if (was.first) {
+          if (was.second) {
+            if (was.third) {
+              addRun(state);
+              runsScored++;
+            }
+            state.runners.third = true;
+          }
+          state.runners.second = true;
+        }
         state.runners.first = true;
         recordEvent(state, {
           type: "walk",


### PR DESCRIPTION
## Summary
- **Fix walk force-advance bug (AB-004)**: Walk handler used simplified runner logic that incorrectly cleared non-forced runners (e.g., runner on 2nd with empty 1st would vanish on a walk). Replaced with the same force-chain logic already proven in the HBP handler. Fixed in both ManualScoreController and scoringEngine.
- **Update all dependencies**: Resolved 16 security vulnerabilities (1 critical, 3 high, 5 moderate, 7 low) → 0 vulnerabilities. Key updates: react-router-dom 7.5→7.13, firebase 11.4→11.10, vite 6.3→6.4, jest 29→30.
- **10 new regression tests** for walk force-advance covering all 8 base-state combinations.

## Test plan
- [x] `npm test` — 42 tests, 5 suites, all pass
- [x] `npm run build` — succeeds
- [x] `npm audit` — 0 vulnerabilities
- [ ] Manual: walk with runner on 2nd only → runner stays on 2nd
- [ ] Manual: bases loaded walk → runner from 3rd scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)