### PR TITLE
Update docs to v0.7.0

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ARCHITECTURE.md — System Map
 
-> Version: 0.5.0 | Last updated: 2026-03-09
+> Version: 0.7.0 | Last updated: 2026-03-10
 
 ## Overview
 
@@ -74,23 +74,31 @@ Scores4Streams_V2/
 │   │   ├── Console.jsx          # Dashboard page wrapper
 │   │   ├── GameCreationForm.jsx # New game form (incl. scoring mode selector)
 │   │   ├── GameList.jsx         # Game list with mode badges
-│   │   ├── ManualScoreController.jsx  # Main scoring UI (all handlers, state)
+│   │   ├── ManualScoreController.jsx  # Main scoring UI (generic handleAction dispatch)
+│   │   ├── FielderPickerModal.jsx     # 3x3 position grid for fielder chains
+│   │   ├── RunnerPickerModal.jsx      # Base runner selection (single/multi)
 │   │   └── EventLog.jsx         # Collapsible play-by-play feed
 │   ├── contexts/
 │   │   ├── AuthContext.jsx      # Firebase Auth + custom claims (user, tenantId, roles)
 │   │   └── FirebaseContext.jsx  # Firebase app instance
 │   ├── hooks/
+│   │   ├── useGameState.js      # useReducer wrapper: scoring engine + undo/redo
 │   │   └── useGameEvents.js     # Event recording: queue, commit, undo/redo, pitch count
 │   ├── pages/
 │   │   ├── LoginPage.jsx        # Login route wrapper
 │   │   ├── ManualScoringPage.jsx # Scoring route wrapper (extracts gameId)
 │   │   └── OverlayFromFigma.jsx # SVG overlay page (public, onSnapshot listener)
 │   ├── utils/
-│   │   ├── scoringEngine.js     # Pure scoring engine for game replay testing
+│   │   ├── scoringEngine.js     # Pure scoring engine — 35 action types, polymorphic dispatch
 │   │   └── updateSVGNodes.js    # SVG DOM manipulation for overlay
 │   ├── __tests__/
 │   │   ├── gameReplay.test.js           # Sunshine vs Knox (5-inning game)
 │   │   ├── gameReplayDrillers.test.js   # Drillers vs Chiefs (7-inning walkoff)
+│   │   ├── objectActions.test.js        # Polymorphic dispatch (8 tests)
+│   │   ├── expandedOuts.test.js         # Expanded out types, DP, TP (22 tests)
+│   │   ├── baseRunning.test.js          # SB, CS, PK, WP, PB, IP (22 tests)
+│   │   ├── battingVariants.test.js      # Sac bunt, bunt hit, D3K, IBB, etc (12 tests)
+│   │   ├── walkForceAdvance.test.js     # AB-004 regression tests (10 tests)
 │   │   ├── OverlayFromFigma.test.jsx    # Overlay unit tests
 │   │   └── OverlayFromFigma.integration.test.jsx
 │   ├── Doco/
@@ -120,13 +128,13 @@ Scores4Streams_V2/
 ## Data Flow: Scoring Action
 
 ```
-1. Scorer taps button (e.g., "Strike")
+1. Scorer taps button (e.g., "Ground Out" → FielderPickerModal → 6-3)
    │
-2. ManualScoreController handler:
-   ├── saveSnapshot() → push to undoStack (for undo/redo)
-   ├── recordEvent() → queue pending event in useGameEvents
-   │   (event has countBefore, type, isPitch, etc.)
-   ├── Update local React state (setBalls, setStrikes, etc.)
+2. ManualScoreController.handleAction(action):
+   ├── Clone state → run applyAction preview → extract new events
+   ├── recordEvent() for each event → queue in useGameEvents (countBefore captured)
+   ├── dispatch(action) → useGameState reducer → applyAction(state, action)
+   │   (useGameState manages undo/redo stacks automatically)
    │
 3. React state change triggers Firestore sync useEffect:
    ├── setDoc(games/{gameId}, { aggregate state }, { merge: true })
@@ -161,9 +169,12 @@ OBS Browser Source → /overlay/{gameId}
 | **Default** | Yes | No (opt-in at game creation) |
 | **Count** | Ball, Strike, Foul, Out | Same |
 | **Hits** | 1B, 2B, 3B, HR | Same |
-| **Plays** | — | E, HBP, FC, SAC |
+| **Outs** | Generic Out | Expandable: GO, FO, LO, PO, FF, IF, K, KC, DP, TP, INT |
+| **Plays** | — | E, HBP, FC, SAC, SAC-B, BH, SL, D3K, IBB, OBS |
+| **Base running** | — | SB, CS, PK, WP, PB (via "More Plays" toggle) |
+| **Fielder tracking** | — | Position picker (e.g., 6-4-3) |
 | **Manual adjustments** | Runner toggles, Score +/- | Same |
-| **Player tracking** | No (batterId/pitcherId null) | Planned |
+| **Player tracking** | No (batterId/pitcherId null) | Planned (Phase 3) |
 | **Events recorded** | Yes (coarse) | Yes (granular play types) |
 | **Target user** | Parent, volunteer | Dedicated scorer/statistician |
 | **Firestore doc** | Same `games/{gameId}` | Same |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 
 ---
 
+## [0.7.0] — 2026-03-10
+
+### Added
+- **Phase 2 play types:** stolen_base, caught_stealing, pick_off, wild_pitch, passed_ball, illegal_pitch, sacrifice_bunt, bunt_hit, slap_hit, dropped_third_strike, intentional_walk, obstruction, interference
+- `FielderPickerModal` — 3x3 position grid for building fielder chains (e.g., 6-4-3)
+- `RunnerPickerModal` — base selection for SB/CS/PK (single) and WP/PB (multi-select)
+- Expandable Out sub-menu in Advanced mode (GO, FO, LO, PO, FF, IF, K, KC, DP, TP, INT)
+- Collapsible "More Plays" toggle for Batting + Base Running sections
+- `baseRunning.test.js` (22 tests), `battingVariants.test.js` (12 tests)
+
+### Changed
+- ManualScoreController decluttered: default view shows 3 button rows + "More Plays" toggle
+
+---
+
+## [0.6.0] — 2026-03-10
+
+### Added
+- **Polymorphic `applyAction`:** accepts string (`"single"`) or object (`{ type: "ground_out", positions: [6, 3] }`)
+- **Expanded out types:** ground_out, fly_out, line_drive_out, popup_out, foul_fly_out, infield_fly, strikeout_swinging, strikeout_looking, double_play, triple_play
+- `runner_toggle` and `score_adjust` action types in engine
+- `useGameState` hook — `useReducer` wrapper with undo/redo stacks and `initFromFirestore`
+- Extracted helpers: `handleForceAdvance`, `handleSingleAdvance`, `formatPositions`
+- `objectActions.test.js` (8 tests), `expandedOuts.test.js` (22 tests)
+
+### Changed
+- ManualScoreController rewritten from 690 → ~350 lines using `useGameState` dispatch
+- Generic `handleAction` pattern replaces 14 duplicated handler functions
+- Double play now properly clears scoring runners (timing play fix)
+
+### Fixed
+- DP pitch overcount resolved: `double_play` action records 2 outs from 1 pitch (AB-006)
+
+---
+
 ## [0.5.0] — 2026-03-09
 
 ### Added

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,6 +1,6 @@
 # MEMORY.md — Quick Reference
 
-> Last updated: 2026-03-09
+> Last updated: 2026-03-10
 
 ## Firebase
 
@@ -13,7 +13,7 @@
 - **Node.js:** v25.6.1 at `/opt/homebrew/bin/node`
 - **PATH prefix:** `export PATH="/opt/homebrew/bin:/usr/bin:$PATH"` (required before npm commands)
 - **Dev server:** Vite on port 5173 (`npm run dev`)
-- **Tests:** Jest (`npm test`) — 5 suites, 42 tests
+- **Tests:** Jest (`npm test`) — 9 suites, 106 tests
 
 ## Routes
 
@@ -66,9 +66,12 @@
 
 | File | Purpose |
 |------|---------|
-| `src/components/ManualScoreController.jsx` | Scoring UI — all action handlers, state management |
+| `src/utils/scoringEngine.js` | Pure scoring engine — 35 action types, polymorphic dispatch |
+| `src/hooks/useGameState.js` | useReducer wrapper around engine with undo/redo stacks |
 | `src/hooks/useGameEvents.js` | Event recording hook — dual-write, pending queue, commit |
-| `src/utils/scoringEngine.js` | Pure scoring engine for testing — mirrors component logic |
+| `src/components/ManualScoreController.jsx` | Scoring UI — generic handleAction, expandable menus |
+| `src/components/FielderPickerModal.jsx` | 3x3 fielder position grid for building chains |
+| `src/components/RunnerPickerModal.jsx` | Base runner selection (single/multi-select) |
 | `src/components/EventLog.jsx` | Collapsible play-by-play feed |
 | `src/components/GameCreationForm.jsx` | New game form with scoring mode selector |
 | `src/components/GameList.jsx` | Game list with mode badges |
@@ -79,7 +82,13 @@
 
 ## Scoring Engine Actions
 
-`ball`, `strike`, `foul`, `out`, `single`, `double`, `triple`, `homerun`, `error`, `hbp`, `fc`, `sac_fly`, `toggle_first`, `toggle_second`, `toggle_third`, `score_home`, `score_away`
+**Count:** `ball`, `strike`, `foul`
+**Hits:** `single`, `double`, `triple`, `homerun`
+**Outs (legacy):** `out`, `strikeout`, `walk`
+**Outs (expanded):** `ground_out`, `fly_out`, `line_drive_out`, `popup_out`, `foul_fly_out`, `infield_fly`, `strikeout_swinging`, `strikeout_looking`, `double_play`, `triple_play`
+**Plays:** `error`, `hbp`, `fc`, `sac_fly`, `sacrifice_bunt`, `bunt_hit`, `slap_hit`, `dropped_third_strike`, `intentional_walk`, `obstruction`, `interference`
+**Base running:** `stolen_base`, `caught_stealing`, `pick_off`, `wild_pitch`, `passed_ball`, `illegal_pitch`
+**Manual:** `toggle_first`, `toggle_second`, `toggle_third`, `score_home`, `score_away`, `runner_toggle`, `score_adjust`
 
 ## Test Game Data
 
@@ -91,14 +100,14 @@
 ## Known Bugs
 
 - ~~Walk force-advance bug~~ **FIXED** — Walk handler now uses the same force-chain logic as HBP. Regression tests in `walkForceAdvance.test.js`.
+- ~~DP pitch overcount~~ **FIXED** — `double_play` action records 2 outs from 1 pitch (AB-006 resolved).
 - **Logo uploads disabled:** Cloud Function for logo processing is incomplete.
 
 ## Known Limitations
 
-- DPs modeled as 2x `out` — overcounts 1 pitch per DP
-- FC-without-out cannot be modeled (FC action always records an out)
-- Pickoff modeled as `out` — overcounts 1 pitch
+- FC-without-out cannot be modeled (FC action always records an out) (AB-007)
 - Runner auto-advancement on hits is simplified (single always advances runner from 2nd to 3rd)
+- Sac fly only scores runner from 3rd — tag-ups from 2nd need manual toggle (AB-009)
 
 ## Version History
 
@@ -109,3 +118,5 @@
 | 0.3.0 | 2026-03-09 | E/HBP/FC/SAC actions, force-advance logic, Drillers test, score_home/score_away |
 | 0.4.0 | 2026-03-09 | Simple vs Advanced scoring mode selection |
 | 0.5.0 | 2026-03-09 | Project workflow: context recovery, ARCHITECTURE.md, MEMORY.md, as-built.md |
+| 0.6.0 | 2026-03-10 | Engine refactor: polymorphic dispatch, expanded outs, useGameState hook, controller rewrite |
+| 0.7.0 | 2026-03-10 | Phase 2 play types, picker modals, decluttered Advanced UI |


### PR DESCRIPTION
## Summary
- CHANGELOG.md: added v0.6.0 and v0.7.0 entries for Phase 1+2 work
- MEMORY.md: updated test count (106), action list (35 types), key files, fixed bugs, version history
- ARCHITECTURE.md: added new components, test suites, updated data flow and scoring modes table

Should have been part of the Phase 1+2 release — adding retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)