### PR TITLE
v1.0.0: L2 practice game test + inherited runner attribution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ARCHITECTURE.md — System Map
 
-> Version: 0.9.0 | Last updated: 2026-03-11
+> Version: 1.0.0 | Last updated: 2026-03-13
 
 ## Overview
 
@@ -102,7 +102,8 @@ Scores4Streams_V2/
 │   │   ├── baseRunning.test.js          # SB, CS, PK, WP, PB, IP (22 tests)
 │   │   ├── battingVariants.test.js      # Sac bunt, bunt hit, D3K, IBB, etc (12 tests)
 │   │   ├── roster.test.js              # Roster helpers, batter auto-advance, validation (39 tests)
-│   │   ├── statsEngine.test.js        # Per-game stats: team/player batting, pitching, fielding (36 tests)
+│   │   ├── gameReplayL2.test.js          # ACT vs SA L2 practice game (17 tests, Advanced mode actions)
+│   │   ├── statsEngine.test.js        # Per-game stats: team/player batting, pitching, fielding (41 tests)
 │   │   ├── walkForceAdvance.test.js     # AB-004 regression tests (10 tests)
 │   │   ├── OverlayFromFigma.test.jsx    # Overlay unit tests
 │   │   └── OverlayFromFigma.integration.test.jsx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 
 ---
 
+## [1.0.0] — 2026-03-13
+
+### Added
+- **L2 Practice Game integration test:** `gameReplayL2.test.js` — 7-inning ACT 6 vs SA 4 game from Softball Australia L2 scoring manual. First test using Advanced mode polymorphic object actions (ground_out, fly_out, line_drive_out, strikeout_swinging, strikeout_looking, error, hbp, wild_pitch, caught_stealing)
+- **Inherited runner attribution:** runs charged to the pitcher who put the runner on base, not the pitcher who allowed the scoring event. Uses `inheritedRunnerPitcherIds` array on events (backward compatible — events without it use old behavior)
+- 5 new inherited runner attribution tests in `statsEngine.test.js`
+
+### Changed
+- Stats engine now redistributes runs when `event.inheritedRunnerPitcherIds` is present
+- Total: 12 test suites, 203 tests
+
+### Known Limitations
+- All runs treated as earned (earned/unearned classification deferred to v1.1.0)
+- No general player substitution action (only `pitcher_change` exists)
+
+---
+
 ## [0.9.0] — 2026-03-11
 
 ### Added

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -13,7 +13,7 @@
 - **Node.js:** v25.6.1 at `/opt/homebrew/bin/node`
 - **PATH prefix:** `export PATH="/opt/homebrew/bin:/usr/bin:$PATH"` (required before npm commands)
 - **Dev server:** Vite on port 5173 (`npm run dev`)
-- **Tests:** Jest (`npm test`) — 11 suites, 181 tests
+- **Tests:** Jest (`npm test`) — 12 suites, 203 tests
 
 ## Routes
 
@@ -100,6 +100,7 @@
 |------|------|-------------|---------------------|
 | Sunshine vs Knox | `gameReplay.test.js` | Away 9 – Home 8 | 5 innings, walks, strikeouts, hits, errors, full-count scenarios |
 | NE Drillers vs Hill United Chiefs | `gameReplayDrillers.test.js` | Away 5 – Home 6 (walkoff) | 7 innings, HBP, sac fly, FC, DPs, stolen bases, pickoff |
+| ACT vs South Australia (L2) | `gameReplayL2.test.js` | ACT 6 – SA 4 | 7 innings, Advanced mode object actions, DP/FLEX lineups, ground/fly/line outs, K swinging/looking, D3K, HR, 2B, 1B, BB, HBP, errors, SB, CS, WP |
 
 ## Known Bugs
 
@@ -112,6 +113,8 @@
 - FC-without-out cannot be modeled (FC action always records an out) (AB-007)
 - Runner auto-advancement on hits is simplified (single always advances runner from 2nd to 3rd)
 - Sac fly only scores runner from 3rd — tag-ups from 2nd need manual toggle (AB-009)
+- All runs treated as earned — earned/unearned classification deferred to v1.1.0
+- Inherited runner attribution supported in statsEngine but requires hooks layer wiring (AB-016)
 
 ## Version History
 
@@ -126,3 +129,4 @@
 | 0.7.0 | 2026-03-10 | Phase 2 play types, picker modals, decluttered Advanced UI |
 | 0.8.0 | 2026-03-10 | Game-level rosters, lineup entry, batter/pitcher tracking, DP/FLEX/DR |
 | 0.9.0 | 2026-03-11 | Per-game statistics engine, batting/pitching/fielding stats, GameStats UI |
+| 1.0.0 | 2026-03-13 | L2 practice game integration test, inherited runner attribution |

--- a/docs/as-built.md
+++ b/docs/as-built.md
@@ -216,10 +216,52 @@ The mode is set at game creation but can be switched mid-game (no data loss — 
 
 **Key choices:**
 - **Ball/strike/foul NOT filtered** — they carry `isPitch: true` which is needed for accurate pitch counts. They pass through batting accumulators harmlessly (not in PA_TYPES).
-- **All runs treated as earned** — no earned/unearned classification yet. ERA uses total runs. Phase 5 adds proper ER logic.
-- **Inherited runners not attributed** — all runs charged to pitcherId on the event, regardless of which pitcher put the runner on base. This is a simplification.
+- **All runs treated as earned** — no earned/unearned classification yet. ERA uses total runs. Earned/unearned deferred to v1.1.0.
+- **Inherited runners attributed via `inheritedRunnerPitcherIds`** — see AB-016.
 - **Fielding stats from positions arrays** — only available in Advanced mode where fielder chains are recorded. Returns null otherwise.
 - **Softball 7-inning ERA** — `ERA = (ER × 7) / IP`, not the baseball 9-inning formula.
 - **WHIP excludes IBB** — `WHIP = (BB - IBB + H) / IP` per standard definition.
 
 **Why it matters:** Don't add incremental stat tracking — it's unnecessary complexity. The event array for a single game is small enough (<500 events) that recomputation is instant. If you add earned run classification, modify `computeGameStats` to separate ER from R, don't add a separate tracking system.
+
+---
+
+## AB-015: L2 Practice Game as Integration Test
+
+**Date:** 2026-03-13 | **Affects:** gameReplayL2.test.js
+
+**Finding:** The two existing game replay tests (Sunshine Knox, Drillers) use legacy string actions (`"out"`, `"single"`, `"strike"`) because they were encoded before Advanced mode existed. No test exercised the full set of polymorphic object actions.
+
+**Decision:** Encoded the Softball Australia L2 manual's practice game (ACT 6 vs SA 4, 7 innings) as a comprehensive integration test. This game exercises ground_out, fly_out, line_drive_out, strikeout_swinging, strikeout_looking, error, hbp, wild_pitch, caught_stealing, and all hit types using Advanced mode object actions.
+
+**Key encoding choices:**
+- **D3K thrown out** → modeled as `strikeout_swinging` (not `dropped_third_strike`, which puts batter ON base)
+- **WP with multiple runner advancement** → one `wild_pitch` action for lead runner + manual toggles for extra advancement
+- **Runner scoring on ground out** → ground_out + `toggle_third` + `score_home`/`score_away`
+- **Substitutions** → comments only (no general substitution action type)
+- **Force out at base** → modeled as `ground_out` with positions
+
+**Why it matters:** This is the first test proving Advanced mode object actions produce correct game state over a full 7-inning game. Any changes to polymorphic action dispatch or runner advancement should be validated against this test.
+
+---
+
+## AB-016: Inherited Runner Attribution
+
+**Date:** 2026-03-13 | **Affects:** statsEngine.js
+
+**Finding:** When pitcher A puts a runner on base and pitcher B allows the hit that scores them, the run should be charged to pitcher A (the pitcher who put the runner on base). The initial stats engine charged all runs to the `pitcherId` on the event (pitcher B).
+
+**Decision:** Optional `inheritedRunnerPitcherIds` array on events. Each entry is the pitcher ID responsible for one run scored. The array length equals `runsScored`. The stats engine redistributes runs after initial accumulation:
+```javascript
+if (event.inheritedRunnerPitcherIds && event.runsScored > 0) {
+  for (const origPitcherId of event.inheritedRunnerPitcherIds) {
+    if (origPitcherId !== event.pitcherId) {
+      // Move 1R + 1ER from current pitcher to original pitcher
+    }
+  }
+}
+```
+
+**Backward compatible:** Events without `inheritedRunnerPitcherIds` charge all runs to `event.pitcherId` (old behavior). The hooks layer (`useGameState`/`useGameEvents`) will need to populate this field when pitcher changes leave inherited runners — that wiring is separate from the stats computation.
+
+**Why it matters:** The stats engine now correctly supports inherited runner attribution, but it requires the event-recording layer to stamp `inheritedRunnerPitcherIds` on events. Until that wiring is done, the stats engine falls back to the old behavior for live games. The 5 tests in statsEngine.test.js verify both the new attribution and backward compatibility.

--- a/src/__tests__/gameReplayL2.test.js
+++ b/src/__tests__/gameReplayL2.test.js
@@ -1,0 +1,535 @@
+/**
+ * Full game replay: ACT vs South Australia — L2 Practice Game
+ * Source: Softball Australia L2 Scoring Manual, Section 17 (pp 27-31)
+ * Date: 5 Jan 2021 — at Blacktown
+ * Final: ACT (Away) 6 - South Australia (Home) 4
+ * Line: ACT  0 0 2 0 2 0 2 = 6 | SA  0 1 0 3 0 0 0 = 4
+ *
+ * First test to use Advanced mode polymorphic object actions:
+ *   ground_out with positions, fly_out, line_drive_out, strikeout_swinging,
+ *   strikeout_looking, error, hbp, wild_pitch, caught_stealing,
+ *   dropped_third_strike, hit with subType
+ *
+ * Features exercised: DP/FLEX lineups, ground outs with fielder chains,
+ * fly outs, line drive outs, KC, K2, D3K (thrown out), HR, doubles,
+ * singles, walks, HBP, errors (E6, E5), stolen bases, caught stealing,
+ * wild pitches, bases-loaded HBP force advance
+ *
+ * Limitations:
+ * - Substitutions not modeled (no sub action yet, only pitcher_change)
+ * - Runner scoring on ground out modeled with toggle + score_away/score_home
+ * - Extra runner advancement on WP modeled with toggle + score_home
+ * - Baumber's at-bat result in Bot 4th inferred as walk (text ambiguous)
+ */
+
+import { createGameState, replayActions } from "../utils/scoringEngine";
+
+describe("Game Replay: ACT vs South Australia — L2 Practice Game", () => {
+  let game;
+
+  beforeEach(() => {
+    game = createGameState("South Australia", "ACT");
+  });
+
+  // ─── TOP 1st: ACT Batting ────────────────────────────────────────
+  // White: Ball, Strike looking, Ball. Ground out 6-3.
+  // McGovern: Strike looking. Ground out 5-3.
+  // Kirkpatrick: Foul, Ball, Ball, Foul, Ball, Ball. Walk.
+  // Norton: Strike, Foul, Ball, Foul, Ball, Foul, Ball. Line out to SS.
+  // Result: 0 runs, 3 outs
+
+  const top1 = [
+    // White: Ball, Strike looking, Ball. Ground out 6-3.
+    "ball", "strike", "ball", { type: "ground_out", positions: [6, 3] },
+    // McGovern: Strike looking. Ground out 5-3.
+    "strike", { type: "ground_out", positions: [5, 3] },
+    // Kirkpatrick: Foul, Ball, Ball, Foul, Ball, Ball → Walk
+    "foul", "ball", "ball", "foul", "ball", "ball",
+    // Norton: Strike, Foul, Ball, Foul, Ball, Foul, Ball. LD out to SS.
+    "strike", "foul", "ball", "foul", "ball", "foul", "ball",
+    { type: "line_drive_out", positions: [6] },
+  ];
+
+  test("Top 1st: ACT 0, SA 0", () => {
+    replayActions(game, top1);
+    expect(game.awayScore).toBe(0);
+    expect(game.homeScore).toBe(0);
+    expect(game.isTop).toBe(false);
+    expect(game.inning).toBe(1);
+    expect(game.outs).toBe(0);
+  });
+
+  // ─── BOT 1st: SA Batting ─────────────────────────────────────────
+  // Harris: Ball, Strike looking. LD out to SS.
+  // Harrison: Strike looking, Strike looking. K swinging.
+  // Farrell: Strike looking, Ball, Strike looking. K swinging.
+  // Result: 0 runs, 3 outs
+
+  const bot1 = [
+    // Harris: Ball, Strike looking. Line drive out to SS.
+    "ball", "strike", { type: "line_drive_out", positions: [6] },
+    // Harrison: Strike looking, Strike looking. K swinging.
+    "strike", "strike", { type: "strikeout_swinging" },
+    // Farrell: Strike looking, Ball, Strike looking. K swinging.
+    "strike", "ball", "strike", { type: "strikeout_swinging" },
+  ];
+
+  test("Bot 1st: ACT 0, SA 0", () => {
+    replayActions(game, [...top1, ...bot1]);
+    expect(game.awayScore).toBe(0);
+    expect(game.homeScore).toBe(0);
+    expect(game.isTop).toBe(true);
+    expect(game.inning).toBe(2);
+  });
+
+  // ─── TOP 2nd: ACT Batting ────────────────────────────────────────
+  // Byrne: Strike, Foul, Ball, Foul, Ball. K swinging.
+  // Jar. Bradbury: Strike looking, Strike swinging. Error by SS (E6).
+  // Jones: Ball, Foul, Strike, Foul, Ball, Foul. K swinging.
+  // Johnson: Ball, Foul, Strike, Ball, Foul. K swinging.
+  // Result: 0 runs, 3 outs (Bradbury stranded on 1st)
+
+  const top2 = [
+    // Byrne: Strike, Foul, Ball, Foul, Ball. K swinging.
+    "strike", "foul", "ball", "foul", "ball", { type: "strikeout_swinging" },
+    // Jar. Bradbury: Strike looking, Strike swinging. Error E6 — reaches 1st.
+    "strike", "strike", { type: "error", positions: [6] },
+    // Jones: Ball, Foul, Strike, Foul, Ball, Foul. K swinging.
+    "ball", "foul", "strike", "foul", "ball", "foul", { type: "strikeout_swinging" },
+    // Johnson: Ball, Foul, Strike, Ball, Foul. K swinging.
+    "ball", "foul", "strike", "ball", "foul", { type: "strikeout_swinging" },
+  ];
+
+  test("Top 2nd: ACT 0, SA 0", () => {
+    replayActions(game, [...top1, ...bot1, ...top2]);
+    expect(game.awayScore).toBe(0);
+    expect(game.homeScore).toBe(0);
+    expect(game.isTop).toBe(false);
+    expect(game.inning).toBe(2);
+  });
+
+  // ─── BOT 2nd: SA Batting ─────────────────────────────────────────
+  // Kipfer: Home run to RF (first pitch).
+  // May: Ball, Strike, Strike. Fly out to RF.
+  // Lach: Ball, Strike, Ball, Strike. LD out to 3B.
+  // Paturis: Ball, Ball, Ball, Strike, Strike, Ball. Walk.
+  // Peterson: Strike, Strike, Ball, Ball, Ball. K swinging.
+  // Result: 1 run (Kipfer HR), 3 outs
+
+  const bot2 = [
+    // Kipfer: Home run to RF (first pitch)
+    "homerun",
+    // May: Ball, Strike, Strike. Fly out to RF.
+    "ball", "strike", "strike", { type: "fly_out", positions: [9] },
+    // Lach: Ball, Strike, Ball, Strike. LD out to 3B.
+    "ball", "strike", "ball", "strike", { type: "line_drive_out", positions: [5] },
+    // Paturis: Ball, Ball, Ball, Strike, Strike, Ball → Walk
+    "ball", "ball", "ball", "strike", "strike", "ball",
+    // Peterson: Strike, Strike, Ball, Ball, Ball. K swinging.
+    "strike", "strike", "ball", "ball", "ball", { type: "strikeout_swinging" },
+  ];
+
+  test("Bot 2nd: ACT 0, SA 1", () => {
+    replayActions(game, [...top1, ...bot1, ...top2, ...bot2]);
+    expect(game.awayScore).toBe(0);
+    expect(game.homeScore).toBe(1);
+    expect(game.isTop).toBe(true);
+    expect(game.inning).toBe(3);
+  });
+
+  // ─── TOP 3rd: ACT Batting ────────────────────────────────────────
+  // Jer. Bradbury: Strike, Ball, Strike. K swinging.
+  // White: Double to CF (first pitch).
+  // McGovern: Ball (WP — White 2nd→3rd). Ground out 1-6-3. White scores.
+  // Kirkpatrick: Ball, Ball. Home run to CF.
+  // Norton: Foul, Ball, Ball, Foul, Foul. Single to CF.
+  // Byrne: Single to CF. Norton advances to 3rd (manual adjust).
+  // Jar. Bradbury: Ball, then Byrne CS 2-6 (3rd out). Norton stranded.
+  // Result: 2 runs (White on GO, Kirkpatrick HR)
+
+  const top3 = [
+    // Jer. Bradbury: Strike, Ball, Strike. K swinging.
+    "strike", "ball", "strike", { type: "strikeout_swinging" },
+    // White: Double to CF (first pitch)
+    "double",
+    // McGovern: Ball (WP advances White 2nd→3rd)
+    "ball", { type: "wild_pitch" },
+    // McGovern: Ground out 1-6-3. White scores from 3rd.
+    { type: "ground_out", positions: [1, 6, 3] },
+    "toggle_third", "score_away", // White scores
+    // Kirkpatrick: Ball, Ball. Home run to CF.
+    "ball", "ball", "homerun",
+    // Norton: Foul, Ball, Ball, Foul, Foul. Single to CF.
+    "foul", "ball", "ball", "foul", "foul", "single",
+    // Byrne: Single to CF. Norton 1st→2nd (engine), need 2nd→3rd manual.
+    "single",
+    "toggle_second", "toggle_third", // Norton 2nd→3rd
+    // Jar. Bradbury: Ball. Byrne CS at 2nd (2-6). 3rd out.
+    "ball", { type: "caught_stealing", runner: "first", positions: [2, 6] },
+  ];
+
+  test("Top 3rd: ACT 2, SA 1", () => {
+    replayActions(game, [...top1, ...bot1, ...top2, ...bot2, ...top3]);
+    expect(game.awayScore).toBe(2);
+    expect(game.homeScore).toBe(1);
+    expect(game.isTop).toBe(false);
+    expect(game.inning).toBe(3);
+  });
+
+  // ─── BOT 3rd: SA Batting ─────────────────────────────────────────
+  // Baumber: Strike, Ball, Strike. K swinging.
+  // Harris: Ball, Ball, Ball, Strike, Strike, Foul, Ball → Walk.
+  // Harrison: Strike, Strike. Fly out to SS.
+  // Farrell: Strike, Ball, Strike. K swinging.
+  // Result: 0 runs, 3 outs (Harris stranded)
+
+  const bot3 = [
+    // Baumber: Strike, Ball, Strike. K swinging.
+    "strike", "ball", "strike", { type: "strikeout_swinging" },
+    // Harris: Ball, Ball, Ball, Strike, Strike, Foul, Ball → Walk
+    "ball", "ball", "ball", "strike", "strike", "foul", "ball",
+    // Harrison: Strike, Strike. Fly out to SS.
+    "strike", "strike", { type: "fly_out", positions: [6] },
+    // Farrell: Strike, Ball, Strike. K swinging.
+    "strike", "ball", "strike", { type: "strikeout_swinging" },
+  ];
+
+  test("Bot 3rd: ACT 2, SA 1", () => {
+    replayActions(game, [...top1, ...bot1, ...top2, ...bot2, ...top3, ...bot3]);
+    expect(game.awayScore).toBe(2);
+    expect(game.homeScore).toBe(1);
+    expect(game.isTop).toBe(true);
+    expect(game.inning).toBe(4);
+  });
+
+  // ─── TOP 4th: ACT Batting ────────────────────────────────────────
+  // Jar. Bradbury: Strike, Strike, Foul, Ball, Ball. Fly out to LF.
+  // Jones: Strike, Strike. K swinging.
+  // Johnson: Ground out 6-3 (first pitch).
+  // Result: 0 runs, 3 outs
+
+  const top4 = [
+    // Jar. Bradbury: Strike, Strike, Foul, Ball, Ball. Fly out to LF.
+    "strike", "strike", "foul", "ball", "ball", { type: "fly_out", positions: [7] },
+    // Jones: Strike, Strike. K swinging.
+    "strike", "strike", { type: "strikeout_swinging" },
+    // Johnson: Ground out 6-3 (first pitch).
+    { type: "ground_out", positions: [6, 3] },
+  ];
+
+  test("Top 4th: ACT 2, SA 1", () => {
+    replayActions(game, [
+      ...top1, ...bot1, ...top2, ...bot2, ...top3, ...bot3, ...top4,
+    ]);
+    expect(game.awayScore).toBe(2);
+    expect(game.homeScore).toBe(1);
+    expect(game.isTop).toBe(false);
+    expect(game.inning).toBe(4);
+  });
+
+  // ─── BOT 4th: SA Batting ─────────────────────────────────────────
+  // Kipfer: Ball, Foul, Ball, Strike, Ball, Ball → Walk.
+  // May: Strike, Ball, Strike, Foul. Double to RF. Kipfer 1st→3rd (engine).
+  // Lach: Strike, Ball. K swinging (D3K thrown out at 1st — still an out).
+  // Paturis: Ball, Strike, Ball, Ball, Ball → Walk. Bases loaded.
+  // Peterson: HBP. Kipfer scores (force), May→3rd, Paturis→2nd.
+  // Baumber: Strike, Ball (WP). May scores from 3rd, then manual:
+  //   Paturis scores from 2nd, Peterson 1st→3rd.
+  //   Baumber walks (3 more balls).
+  // Harris: Ball, Foul, Ball, Ball. Ground out 1-3.
+  // Harrison: Ball, Ball, Strike, Foul, Ball. K swinging.
+  // Result: 3 runs (Kipfer on HBP force, May + Paturis on WP)
+
+  const bot4 = [
+    // Kipfer: Ball, Foul, Ball, Strike, Ball, Ball → Walk
+    "ball", "foul", "ball", "strike", "ball", "ball",
+    // May: Strike, Ball, Strike, Foul. Double to RF. Kipfer 1st→3rd (engine handles).
+    "strike", "ball", "strike", "foul", "double",
+    // Lach: Strike, Ball. K swinging (D3K but thrown out — modeled as K)
+    "strike", "ball", { type: "strikeout_swinging" },
+    // Paturis: Ball, Strike, Ball, Ball, Ball → Walk. Bases loaded.
+    "ball", "strike", "ball", "ball", "ball",
+    // Peterson: HBP. Kipfer scores (force advance), May→3rd, Paturis→2nd.
+    { type: "hbp" },
+    // Baumber: Strike looking, Ball (same pitch = WP)
+    "strike", "ball",
+    // WP: May scores from 3rd (engine default — lead runner)
+    { type: "wild_pitch" },
+    // Manual: Paturis scores from 2nd
+    "toggle_second", "score_home",
+    // Manual: Peterson 1st→3rd
+    "toggle_first", "toggle_third",
+    // Baumber continues: Ball, Ball, Ball → Walk (count was 1-1, now 4-1)
+    "ball", "ball", "ball",
+    // Harris: Ball, Foul, Ball, Ball. Ground out 1-3.
+    "ball", "foul", "ball", "ball", { type: "ground_out", positions: [1, 3] },
+    // Harrison: Ball, Ball, Strike, Foul, Ball. K swinging.
+    "ball", "ball", "strike", "foul", "ball", { type: "strikeout_swinging" },
+  ];
+
+  test("Bot 4th: ACT 2, SA 4", () => {
+    replayActions(game, [
+      ...top1, ...bot1, ...top2, ...bot2, ...top3, ...bot3, ...top4,
+      ...bot4,
+    ]);
+    expect(game.awayScore).toBe(2);
+    expect(game.homeScore).toBe(4);
+    expect(game.isTop).toBe(true);
+    expect(game.inning).toBe(5);
+  });
+
+  // ─── TOP 5th: ACT Batting ────────────────────────────────────────
+  // Jer. Bradbury: Strike, Ball, Foul. K swinging.
+  // White: Ball, Foul, Foul. K looking.
+  // McGovern: Home run to CF (first pitch).
+  // Kirkpatrick: Home run to CF (first pitch).
+  // Norton: Foul, Ball, Ball, Ball. Single to CF.
+  // Byrne: Fly out to 2B (first pitch).
+  // Result: 2 runs (McGovern HR, Kirkpatrick HR)
+
+  const top5 = [
+    // Jer. Bradbury: Strike, Ball, Foul. K swinging.
+    "strike", "ball", "foul", { type: "strikeout_swinging" },
+    // White: Ball, Foul, Foul. K looking.
+    "ball", "foul", "foul", { type: "strikeout_looking" },
+    // McGovern: Home run to CF (first pitch)
+    "homerun",
+    // Kirkpatrick: Home run to CF (first pitch)
+    "homerun",
+    // Norton: Foul, Ball, Ball, Ball. Single to CF.
+    "foul", "ball", "ball", "ball", "single",
+    // Byrne: Fly out to 2B (first pitch).
+    { type: "fly_out", positions: [2] },
+  ];
+
+  test("Top 5th: ACT 4, SA 4", () => {
+    replayActions(game, [
+      ...top1, ...bot1, ...top2, ...bot2, ...top3, ...bot3, ...top4,
+      ...bot4, ...top5,
+    ]);
+    expect(game.awayScore).toBe(4);
+    expect(game.homeScore).toBe(4);
+    expect(game.isTop).toBe(false);
+    expect(game.inning).toBe(5);
+  });
+
+  // ─── BOT 5th: SA Batting ─────────────────────────────────────────
+  // Farrell: Single to SS (first pitch).
+  // Kipfer: Foul, Foul, Ball. K swinging.
+  // May: Strike, Strike, Ball. K swinging.
+  // Lach: Strike looking. Ground out 1-3.
+  // Result: 0 runs, 3 outs (Farrell stranded)
+
+  const bot5 = [
+    // Farrell: Single to SS (first pitch). Text says "Singles to short stop."
+    "single",
+    // Kipfer: Foul, Foul, Ball. K swinging.
+    "foul", "foul", "ball", { type: "strikeout_swinging" },
+    // May: Strike, Strike, Ball. K swinging.
+    "strike", "strike", "ball", { type: "strikeout_swinging" },
+    // Lach: Strike looking. Ground out 1-3.
+    "strike", { type: "ground_out", positions: [1, 3] },
+  ];
+
+  test("Bot 5th: ACT 4, SA 4", () => {
+    replayActions(game, [
+      ...top1, ...bot1, ...top2, ...bot2, ...top3, ...bot3, ...top4,
+      ...bot4, ...top5, ...bot5,
+    ]);
+    expect(game.awayScore).toBe(4);
+    expect(game.homeScore).toBe(4);
+    expect(game.isTop).toBe(true);
+    expect(game.inning).toBe(6);
+  });
+
+  // ─── TOP 6th: ACT Batting ────────────────────────────────────────
+  // (Subs: Jones→Harrow, Johnson→Wickham — no engine action)
+  // Jar. Bradbury: Strike swinging. Ground out 1-3.
+  // Harrow: Strike, Strike. K looking.
+  // Wickham: Strike looking, Strike swinging. K looking.
+  // Result: 0 runs, 3 outs
+
+  const top6 = [
+    // Jar. Bradbury: Strike swinging. Ground out 1-3.
+    "strike", { type: "ground_out", positions: [1, 3] },
+    // Harrow: Strike, Strike. K looking.
+    "strike", "strike", { type: "strikeout_looking" },
+    // Wickham: Strike looking, Strike swinging. K looking.
+    "strike", "strike", { type: "strikeout_looking" },
+  ];
+
+  test("Top 6th: ACT 4, SA 4", () => {
+    replayActions(game, [
+      ...top1, ...bot1, ...top2, ...bot2, ...top3, ...bot3, ...top4,
+      ...bot4, ...top5, ...bot5, ...top6,
+    ]);
+    expect(game.awayScore).toBe(4);
+    expect(game.homeScore).toBe(4);
+    expect(game.isTop).toBe(false);
+    expect(game.inning).toBe(6);
+  });
+
+  // ─── BOT 6th: SA Batting ─────────────────────────────────────────
+  // (Subs: Jones RE, Johnson RE — fielding. Peterson→Jackson)
+  // Paturis: Foul, Strike, Ball. K swinging.
+  // Jackson: Strike looking. Error by 3B (E5) — reaches 1st.
+  // Baumber: Strike looking. Ground out 6-3. Jackson to 2nd.
+  // Harris: Ground out 6-3 (first pitch).
+  // Result: 0 runs, 3 outs
+
+  const bot6 = [
+    // Paturis: Foul, Strike, Ball. K swinging.
+    "foul", "strike", "ball", { type: "strikeout_swinging" },
+    // Jackson: Strike looking. Error E5 — reaches 1st.
+    "strike", { type: "error", positions: [5] },
+    // Baumber: Strike looking. Ground out 6-3. Jackson to 2nd (manual).
+    "strike", { type: "ground_out", positions: [6, 3] },
+    "toggle_first", "toggle_second", // Jackson 1st→2nd
+    // Harris: Ground out 6-3 (first pitch). 3rd out.
+    { type: "ground_out", positions: [6, 3] },
+  ];
+
+  test("Bot 6th: ACT 4, SA 4", () => {
+    replayActions(game, [
+      ...top1, ...bot1, ...top2, ...bot2, ...top3, ...bot3, ...top4,
+      ...bot4, ...top5, ...bot5, ...top6, ...bot6,
+    ]);
+    expect(game.awayScore).toBe(4);
+    expect(game.homeScore).toBe(4);
+    expect(game.isTop).toBe(true);
+    expect(game.inning).toBe(7);
+  });
+
+  // ─── TOP 7th: ACT Batting ────────────────────────────────────────
+  // (Subs: Jer. Bradbury→Nussbaum, then Jer. Bradbury RE)
+  // Nussbaum: Ball, Strike, Strike. Single to CF.
+  // White: Ball, Strike, Foul, Ball, Foul, Foul, Ball, Ball → Walk.
+  //   Nussbaum (via re-entry as Jer. Bradbury) to 2nd. Engine: force advance.
+  // McGovern: Ball, Foul, Strike, Ball. K looking.
+  // Kirkpatrick: Strike, Strike. Double to CF.
+  //   Jer. Bradbury (2nd) scores, White (1st) → 3rd. Engine handles double.
+  // Norton: Strike looking. Ground out 5-3. White scores from 3rd (manual).
+  //   Kirkpatrick to 3rd (manual).
+  // Byrne: Fly out to RF (first pitch).
+  // Result: 2 runs (Bradbury on double, White on ground out)
+
+  const top7 = [
+    // Nussbaum/Jer. Bradbury: Ball, Strike, Strike. Single to CF.
+    "ball", "strike", "strike", "single",
+    // White: Ball, Strike, Foul, Ball, Foul, Foul, Ball, Ball → Walk
+    // Walk force-advances Nussbaum 1st→2nd.
+    "ball", "strike", "foul", "ball", "foul", "foul", "ball", "ball",
+    // McGovern: Ball, Foul, Strike, Ball. K looking.
+    "ball", "foul", "strike", "ball", { type: "strikeout_looking" },
+    // Kirkpatrick: Strike, Strike. Double to CF.
+    // Engine: 2nd (Bradbury) scores, 1st (White) → 3rd, Kirkpatrick → 2nd.
+    "strike", "strike", "double",
+    // Norton: Strike looking. Ground out 5-3. White scores from 3rd.
+    "strike", { type: "ground_out", positions: [5, 3] },
+    "toggle_third", "score_away", // White scores from 3rd
+    // Manual: Kirkpatrick 2nd→3rd
+    "toggle_second", "toggle_third",
+    // Byrne: Fly out to RF (first pitch).
+    { type: "fly_out", positions: [9] },
+  ];
+
+  test("Top 7th: ACT 6, SA 4", () => {
+    replayActions(game, [
+      ...top1, ...bot1, ...top2, ...bot2, ...top3, ...bot3, ...top4,
+      ...bot4, ...top5, ...bot5, ...top6, ...bot6, ...top7,
+    ]);
+    expect(game.awayScore).toBe(6);
+    expect(game.homeScore).toBe(4);
+    expect(game.isTop).toBe(false);
+    expect(game.inning).toBe(7);
+  });
+
+  // ─── BOT 7th: SA Batting ─────────────────────────────────────────
+  // Harrison: Strike, Strike, Foul. Fly out to 3B.
+  // Farrell: Strike, Ball, Strike, Ball, Foul, Foul. Single to LF.
+  // Kipfer: Strike looking. Fly out to RF.
+  // May: Strike swinging. Ground out 6 (force out at 2nd, unassisted).
+  // Result: 0 runs, 3 outs. GAME OVER. ACT 6, SA 4.
+
+  const bot7 = [
+    // Harrison: Strike, Strike, Foul. Fly out to 3B.
+    "strike", "strike", "foul", { type: "fly_out", positions: [5] },
+    // Farrell: Strike, Ball, Strike, Ball, Foul, Foul. Single to LF.
+    "strike", "ball", "strike", "ball", "foul", "foul",
+    "single",
+    // Kipfer: Strike looking. Fly out to RF.
+    "strike", { type: "fly_out", positions: [9] },
+    // May: Strike swinging. Ground out — force at 2nd, SS unassisted (PO6).
+    "strike", { type: "ground_out", positions: [6] },
+  ];
+
+  test("Bot 7th: ACT 6, SA 4 — GAME OVER", () => {
+    replayActions(game, [
+      ...top1, ...bot1, ...top2, ...bot2, ...top3, ...bot3, ...top4,
+      ...bot4, ...top5, ...bot5, ...top6, ...bot6, ...top7, ...bot7,
+    ]);
+    expect(game.awayScore).toBe(6);
+    expect(game.homeScore).toBe(4);
+    // After Bot 7th with 3 outs, changes to Top 8th
+    expect(game.isTop).toBe(true);
+    expect(game.inning).toBe(8);
+    expect(game.outs).toBe(0);
+  });
+
+  // ─── FULL GAME VERIFICATION ──────────────────────────────────────
+
+  test("Final score: ACT 6, SA 4 after 7 complete innings", () => {
+    const allActions = [
+      ...top1, ...bot1, ...top2, ...bot2, ...top3, ...bot3, ...top4,
+      ...bot4, ...top5, ...bot5, ...top6, ...bot6, ...top7, ...bot7,
+    ];
+    replayActions(game, allActions);
+    expect(game.awayScore).toBe(6);
+    expect(game.homeScore).toBe(4);
+  });
+
+  test("Events array is populated with play-by-play", () => {
+    const allActions = [
+      ...top1, ...bot1, ...top2, ...bot2, ...top3, ...bot3, ...top4,
+      ...bot4, ...top5, ...bot5, ...top6, ...bot6, ...top7, ...bot7,
+    ];
+    replayActions(game, allActions);
+    // Should have many events (pitches, plays, toggles)
+    expect(game.events.length).toBeGreaterThan(100);
+    // Verify some specific event types exist
+    const types = game.events.map((e) => e.type);
+    expect(types).toContain("ground_out");
+    expect(types).toContain("fly_out");
+    expect(types).toContain("line_drive_out");
+    expect(types).toContain("strikeout_swinging");
+    expect(types).toContain("strikeout_looking");
+    expect(types).toContain("error");
+    expect(types).toContain("hbp");
+    expect(types).toContain("wild_pitch");
+    expect(types).toContain("caught_stealing");
+    expect(types).toContain("hit");
+    expect(types).toContain("walk");
+  });
+
+  test("Per-inning scoring is correct", () => {
+    // Verify score at the end of each full inning
+    const innings = [
+      { actions: [...top1, ...bot1], away: 0, home: 0, label: "Inn 1" },
+      { actions: [...top2, ...bot2], away: 0, home: 1, label: "Inn 2" },
+      { actions: [...top3, ...bot3], away: 2, home: 1, label: "Inn 3" },
+      { actions: [...top4, ...bot4], away: 2, home: 4, label: "Inn 4" },
+      { actions: [...top5, ...bot5], away: 4, home: 4, label: "Inn 5" },
+      { actions: [...top6, ...bot6], away: 4, home: 4, label: "Inn 6" },
+      { actions: [...top7, ...bot7], away: 6, home: 4, label: "Inn 7" },
+    ];
+
+    let cumulative = [];
+    for (const inn of innings) {
+      cumulative = [...cumulative, ...inn.actions];
+      const g = createGameState("South Australia", "ACT");
+      replayActions(g, cumulative);
+      expect(g.awayScore).toBe(inn.away); // ACT
+      expect(g.homeScore).toBe(inn.home); // SA
+    }
+  });
+});

--- a/src/__tests__/statsEngine.test.js
+++ b/src/__tests__/statsEngine.test.js
@@ -516,7 +516,191 @@ describe("statsEngine", () => {
       const p2 = homePitching.find((p) => p.playerId === "p2");
       expect(p2.BF).toBe(1);
       expect(p2.H).toBe(1); // HR is a hit
-      expect(p2.R).toBe(2); // 2 runs: batter + inherited runner (inherited runner attribution deferred)
+      expect(p2.R).toBe(2); // 2 runs (no inheritedRunnerPitcherIds → all to current pitcher)
+    });
+
+    test("inherited runner attribution: run charged to original pitcher", () => {
+      const game = createGameState("Home", "Away");
+
+      game.homeRoster = [
+        makePlayer("pA", "PitcherA", 10, 1, "P"),
+        makePlayer("pB", "PitcherB", 20, 2, "P"),
+      ];
+
+      // pA allows a single (runner on 1st)
+      applyAction(game, "single");
+      game.events[game.events.length - 1].pitcherId = "pA";
+
+      // pA records an out
+      applyAction(game, "out");
+      game.events[game.events.length - 1].pitcherId = "pA";
+
+      // Pitcher change: pA → pB
+      applyAction(game, { type: "pitcher_change", team: "home", pitcherId: "pB" });
+
+      // pB gives up a HR scoring inherited runner + batter = 2 runs
+      applyAction(game, "homerun");
+      const hrEvent = game.events[game.events.length - 1];
+      hrEvent.pitcherId = "pB";
+      // The inherited runner was put on by pA
+      hrEvent.inheritedRunnerPitcherIds = ["pA", "pB"];
+
+      const stats = computeGameStats(game.events, game.homeRoster, null);
+      const pitching = stats.home.players.pitching;
+
+      const pA = pitching.find((p) => p.playerId === "pA");
+      expect(pA.R).toBe(1);  // Inherited runner charged to pA
+      expect(pA.ER).toBe(1);
+
+      const pB = pitching.find((p) => p.playerId === "pB");
+      expect(pB.R).toBe(1);  // Only the batter's run charged to pB
+      expect(pB.ER).toBe(1);
+    });
+
+    test("inherited runner: all runs to new pitcher when no inherited runners", () => {
+      const game = createGameState("Home", "Away");
+
+      game.homeRoster = [
+        makePlayer("pA", "PitcherA", 10, 1, "P"),
+        makePlayer("pB", "PitcherB", 20, 2, "P"),
+      ];
+
+      // pA pitches 3 outs, no runners
+      applyAction(game, "out");
+      game.events[game.events.length - 1].pitcherId = "pA";
+      applyAction(game, "out");
+      game.events[game.events.length - 1].pitcherId = "pA";
+      applyAction(game, "out");
+      game.events[game.events.length - 1].pitcherId = "pA";
+
+      // Side change
+      applyAction(game, "out");
+      applyAction(game, "out");
+      applyAction(game, "out");
+
+      // New inning top, pB pitches
+      applyAction(game, { type: "pitcher_change", team: "home", pitcherId: "pB" });
+      applyAction(game, "single");
+      game.events[game.events.length - 1].pitcherId = "pB";
+      applyAction(game, "homerun");
+      const hrEvent = game.events[game.events.length - 1];
+      hrEvent.pitcherId = "pB";
+      // Both runs belong to pB (no inherited runner)
+      hrEvent.inheritedRunnerPitcherIds = ["pB", "pB"];
+
+      const stats = computeGameStats(game.events, game.homeRoster, null);
+      const pitching = stats.home.players.pitching;
+
+      const pA = pitching.find((p) => p.playerId === "pA");
+      expect(pA.R).toBe(0);
+
+      const pB = pitching.find((p) => p.playerId === "pB");
+      expect(pB.R).toBe(2);
+    });
+
+    test("inherited runner scores on wild pitch — charged to original pitcher", () => {
+      const game = createGameState("Home", "Away");
+
+      game.homeRoster = [
+        makePlayer("pA", "PitcherA", 10, 1, "P"),
+        makePlayer("pB", "PitcherB", 20, 2, "P"),
+      ];
+
+      // pA walks a batter
+      replayActions(game, ["ball", "ball", "ball", "ball"]);
+      game.events[game.events.length - 1].pitcherId = "pA";
+
+      // Manual advance runner to 3rd for testing
+      applyAction(game, "toggle_first");
+      applyAction(game, "toggle_third");
+
+      // Pitcher change
+      applyAction(game, { type: "pitcher_change", team: "home", pitcherId: "pB" });
+
+      // Wild pitch scores the runner from 3rd
+      applyAction(game, { type: "wild_pitch", runners: ["third"] });
+      const wpEvent = game.events[game.events.length - 1];
+      wpEvent.pitcherId = "pB";
+      wpEvent.inheritedRunnerPitcherIds = ["pA"];
+
+      const stats = computeGameStats(game.events, game.homeRoster, null);
+      const pitching = stats.home.players.pitching;
+
+      const pA = pitching.find((p) => p.playerId === "pA");
+      expect(pA.R).toBe(1);  // Run charged to pA (put the runner on)
+      expect(pA.WP).toBe(0); // WP stat stays on pB
+
+      const pB = pitching.find((p) => p.playerId === "pB");
+      expect(pB.R).toBe(0);  // No runs charged
+      expect(pB.WP).toBe(1); // WP counted for pB
+    });
+
+    test("multiple inherited runners from different pitchers", () => {
+      const game = createGameState("Home", "Away");
+
+      game.homeRoster = [
+        makePlayer("pA", "PitcherA", 10, 1, "P"),
+        makePlayer("pB", "PitcherB", 20, 2, "P"),
+        makePlayer("pC", "PitcherC", 30, 3, "P"),
+      ];
+
+      // pA allows a single
+      applyAction(game, "single");
+      game.events[game.events.length - 1].pitcherId = "pA";
+
+      // pB comes in and allows a single (pA runner on 2nd, pB runner on 1st)
+      applyAction(game, { type: "pitcher_change", team: "home", pitcherId: "pB" });
+      applyAction(game, "single");
+      game.events[game.events.length - 1].pitcherId = "pB";
+
+      // pC comes in and gives up a HR scoring all 3
+      applyAction(game, { type: "pitcher_change", team: "home", pitcherId: "pC" });
+      applyAction(game, "homerun");
+      const hrEvent = game.events[game.events.length - 1];
+      hrEvent.pitcherId = "pC";
+      // 3 runs: inherited from pA, inherited from pB, batter (pC)
+      hrEvent.inheritedRunnerPitcherIds = ["pA", "pB", "pC"];
+
+      const stats = computeGameStats(game.events, game.homeRoster, null);
+      const pitching = stats.home.players.pitching;
+
+      const pA = pitching.find((p) => p.playerId === "pA");
+      expect(pA.R).toBe(1);
+
+      const pB = pitching.find((p) => p.playerId === "pB");
+      expect(pB.R).toBe(1);
+
+      const pC = pitching.find((p) => p.playerId === "pC");
+      expect(pC.R).toBe(1);
+    });
+
+    test("backward compat: events without inheritedRunnerPitcherIds charge all to pitcherId", () => {
+      const game = createGameState("Home", "Away");
+
+      game.homeRoster = [
+        makePlayer("pA", "PitcherA", 10, 1, "P"),
+        makePlayer("pB", "PitcherB", 20, 2, "P"),
+      ];
+
+      // pA allows a runner
+      applyAction(game, "single");
+      game.events[game.events.length - 1].pitcherId = "pA";
+
+      applyAction(game, { type: "pitcher_change", team: "home", pitcherId: "pB" });
+
+      // pB gives up HR but NO inheritedRunnerPitcherIds (old event format)
+      applyAction(game, "homerun");
+      game.events[game.events.length - 1].pitcherId = "pB";
+      // No inheritedRunnerPitcherIds set — backward compat
+
+      const stats = computeGameStats(game.events, game.homeRoster, null);
+      const pitching = stats.home.players.pitching;
+
+      const pA = pitching.find((p) => p.playerId === "pA");
+      expect(pA.R).toBe(0);  // No inherited attribution without the array
+
+      const pB = pitching.find((p) => p.playerId === "pB");
+      expect(pB.R).toBe(2);  // All runs charged to current pitcher (old behavior)
     });
   });
 

--- a/src/utils/statsEngine.js
+++ b/src/utils/statsEngine.js
@@ -6,9 +6,10 @@
  * Handles both team-level (always available) and per-player (when rosters exist).
  *
  * Known limitations:
- * - All runs treated as earned (earned/unearned classification in Phase 5)
+ * - All runs treated as earned (earned/unearned classification deferred)
  * - Fielding stats require positions arrays (Advanced mode only)
  * - Softball 7-inning game assumed for rate stats (ERA, K/9, BB/9)
+ * - Inherited runner attribution requires `inheritedRunnerPitcherIds` on events
  */
 
 // ─── Constants ──────────────────────────────────────────────────
@@ -228,7 +229,7 @@ function accumulatePitchingEvent(line, event) {
   // Runs allowed (all events including base running)
   if (event.runsScored) {
     line.R += event.runsScored;
-    line.ER += event.runsScored; // All earned for now (Phase 5 fixes)
+    line.ER += event.runsScored; // All earned for now (earned/unearned deferred)
   }
 
   // Walks
@@ -474,6 +475,23 @@ function computePlayerStats(allEvents, roster, isAway) {
       pitchingByPlayer[event.pitcherId] = emptyPitchingLine();
     }
     accumulatePitchingEvent(pitchingByPlayer[event.pitcherId], event);
+
+    // Inherited runner attribution: redistribute runs to original pitchers
+    if (event.inheritedRunnerPitcherIds && event.runsScored > 0) {
+      const currentLine = pitchingByPlayer[event.pitcherId];
+      for (const origPitcherId of event.inheritedRunnerPitcherIds) {
+        if (origPitcherId !== event.pitcherId) {
+          // Move 1 R + 1 ER from current pitcher to original pitcher
+          currentLine.R--;
+          currentLine.ER--;
+          if (!pitchingByPlayer[origPitcherId]) {
+            pitchingByPlayer[origPitcherId] = emptyPitchingLine();
+          }
+          pitchingByPlayer[origPitcherId].R++;
+          pitchingByPlayer[origPitcherId].ER++;
+        }
+      }
+    }
   }
 
   // Compute rates and attach player info


### PR DESCRIPTION
## Summary
- **L2 Practice Game Integration Test** (`gameReplayL2.test.js`): Full 7-inning game from Softball Australia L2 scoring manual (ACT 6 vs SA 4). First test using Advanced mode polymorphic object actions — exercises ground_out, fly_out, line_drive_out, strikeout_swinging/looking, error, hbp, wild_pitch, caught_stealing, and all hit types. 17 tests.
- **Inherited Runner Attribution** (`statsEngine.js`): Runs now correctly charged to the pitcher who put the runner on base via `inheritedRunnerPitcherIds` array on events. Backward compatible — old events use previous behavior. 5 new tests.
- **Doc updates**: CHANGELOG v1.0.0, ARCHITECTURE v1.0.0, MEMORY (test counts, version), as-built AB-015 + AB-016.

## Test plan
- [x] All 203 tests pass (12 suites)
- [x] Production build succeeds
- [x] L2 test verifies ACT 6 vs SA 4 final score and per-inning scoring
- [x] Inherited runner attribution: 5 scenarios (basic, no inherited, WP, multi-pitcher, backward compat)
- [x] No regressions in existing 181 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)