### PR TITLE
v1.3.0: Bottom tab navigation + player names on diamond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 
 ---
 
+## [1.3.0] — 2026-03-15
+
+### Added
+- **Bottom tab bar navigation:** Score / Stats / Settings tabs, persistent across pages
+- **Settings page:** User profile, team switching, sign out, app version (moved from Console)
+- **Stats page:** Placeholder for upcoming statistics features
+- **Player names on diamond:** Occupied bases show `#number LastName` labels
+- New routes: `/stats`, `/settings`
+
+### Changed
+- Console simplified — profile section moved to Settings page
+- Router restructured with layout route pattern for NavBar support
+- Nav bar hidden during live scoring and overlay views
+
+---
+
 ## [1.2.0] — 2026-03-14
 
 ### Added

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -132,3 +132,4 @@
 | 1.0.0 | 2026-03-13 | L2 practice game integration test, inherited runner attribution |
 | 1.1.0 | 2026-03-14 | Lineup validation: duplicate position prevention, first/last name split |
 | 1.2.0 | 2026-03-14 | Responsive layout: phone/tablet/desktop breakpoints, one-screen scoring on mobile |
+| 1.3.0 | 2026-03-15 | Bottom tab navigation, Settings page, player names on diamond |

--- a/src/App.css
+++ b/src/App.css
@@ -1488,6 +1488,92 @@ label input, label select {
   text-overflow: ellipsis;
 }
 
+/* === Bottom Nav Bar === */
+.nav-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  height: 56px;
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-color);
+  z-index: 20;
+}
+
+.nav-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  flex: 1;
+  height: 100%;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.nav-tab.active {
+  color: var(--accent-blue);
+}
+
+.nav-icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.nav-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+/* Pages with nav bar need bottom padding to avoid overlap */
+.console-page,
+.stats-page,
+.settings-page {
+  padding-bottom: 68px;
+}
+
+/* === Runner Labels on Diamond === */
+.runner-label {
+  position: absolute;
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--accent-yellow);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 70px;
+  text-align: center;
+  pointer-events: none;
+}
+
+.runner-label-second {
+  top: 26px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.runner-label-third {
+  top: calc(50% + 14px);
+  left: -4px;
+  text-align: left;
+  transform: none;
+}
+
+.runner-label-first {
+  top: calc(50% + 14px);
+  right: -4px;
+  text-align: right;
+  transform: none;
+}
+
 /* === Responsive === */
 
 /* ── Tablet (600px+) ── */
@@ -1590,6 +1676,31 @@ label input, label select {
   .action-section {
     padding: 0 16px 12px;
   }
+
+  /* Larger runner labels on tablet */
+  .runner-label {
+    font-size: 11px;
+    max-width: 90px;
+  }
+
+  .runner-label-second {
+    top: 32px;
+  }
+
+  .runner-label-third {
+    top: calc(50% + 18px);
+  }
+
+  .runner-label-first {
+    top: calc(50% + 18px);
+  }
+
+  /* Nav bar centered on tablet */
+  .nav-bar {
+    max-width: 768px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
 }
 
 /* ── Desktop / iPad landscape (1024px+) ── */
@@ -1605,5 +1716,9 @@ label input, label select {
   .bso-diamond-row {
     gap: 48px;
     padding: 16px 32px;
+  }
+
+  .nav-bar {
+    max-width: 1024px;
   }
 }

--- a/src/components/Console.jsx
+++ b/src/components/Console.jsx
@@ -1,37 +1,12 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { getFirestore, doc, getDoc, updateDoc } from "firebase/firestore";
-import { getAuth, signOut } from "firebase/auth";
 import { useAuth } from "../contexts/AuthContext";
-import { callSetCustomClaims } from "../utils/authUtils";
 import GameCreationForm from "./GameCreationForm";
 import GameList from "./GameList";
 
 const Console = () => {
-  const { user, tenantId, loading } = useAuth();
+  const { user, loading } = useAuth();
   const navigate = useNavigate();
-  const [memberships, setMemberships] = useState({});
-  const [activeTenant, setActiveTenant] = useState(tenantId);
-  const [updating, setUpdating] = useState(false);
-
-  useEffect(() => {
-    const fetchUserData = async () => {
-      if (!user) return;
-      const db = getFirestore();
-      const userRef = doc(db, "users", user.uid);
-      try {
-        const userSnap = await getDoc(userRef);
-        if (userSnap.exists()) {
-          const data = userSnap.data();
-          setMemberships(data.memberships || {});
-          setActiveTenant(data.activeTenant);
-        }
-      } catch (err) {
-        console.error("Error fetching user data:", err);
-      }
-    };
-    fetchUserData();
-  }, [user]);
 
   useEffect(() => {
     if (user) {
@@ -39,71 +14,16 @@ const Console = () => {
     }
   }, [user]);
 
-  const handleSwitchTeam = async (newTenantId) => {
-    if (!user || newTenantId === activeTenant) return;
-    setUpdating(true);
-    const db = getFirestore();
-    const userRef = doc(db, "users", user.uid);
-    await updateDoc(userRef, { activeTenant: newTenantId });
-    await callSetCustomClaims();
-    setActiveTenant(newTenantId);
-    setUpdating(false);
-  };
-
-  const handleSignOut = async () => {
-    const auth = getAuth();
-    await signOut(auth);
-    navigate("/login");
-  };
-
   if (loading) return <div className="loading-page">Loading...</div>;
   if (!user && !loading) {
     navigate("/login");
     return null;
   }
 
-  const currentRoles = Array.isArray(memberships?.[activeTenant]?.roles)
-    ? memberships[activeTenant].roles.join(", ")
-    : "none";
-
   return (
     <div className="console-page">
       <div className="page-header">
         <h2>Scores4Streams</h2>
-      </div>
-
-      <div className="card" style={{ marginTop: 12 }}>
-        <h3>Profile</h3>
-        <p className="profile-info"><strong>Email:</strong> {user?.email}</p>
-        <p className="profile-info"><strong>Role(s):</strong> {currentRoles}</p>
-        <p className="profile-info"><strong>Active Team:</strong> {activeTenant}</p>
-
-        {Object.keys(memberships).length > 1 && (
-          <div style={{ marginTop: 12 }}>
-            <h3>Switch Team</h3>
-            <ul className="team-list">
-              {Object.entries(memberships).map(([teamId, info]) => (
-                <li key={teamId}>
-                  <button
-                    disabled={updating || teamId === activeTenant}
-                    onClick={() => handleSwitchTeam(teamId)}
-                  >
-                    {teamId} ({Array.isArray(info.roles) ? info.roles.join(", ") : "no roles"})
-                    {teamId === activeTenant ? " (active)" : ""}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        <button
-          className="btn-danger btn-small"
-          onClick={handleSignOut}
-          style={{ marginTop: 12 }}
-        >
-          Sign Out
-        </button>
       </div>
 
       <div className="card">

--- a/src/components/ManualScoreController.jsx
+++ b/src/components/ManualScoreController.jsx
@@ -4,7 +4,7 @@ import { useAuth } from "../contexts/AuthContext";
 import useGameEvents from "../hooks/useGameEvents";
 import useGameState from "../hooks/useGameState";
 import { applyAction } from "../utils/scoringEngine";
-import { getCurrentBatter, getCurrentPitcher } from "../utils/rosterHelpers";
+import { getCurrentBatter, getCurrentPitcher, getPlayerById } from "../utils/rosterHelpers";
 import EventLog from "./EventLog";
 import GameStats from "./GameStats";
 import FielderPickerModal from "./FielderPickerModal";
@@ -465,14 +465,26 @@ const ManualScoreController = ({ gameId }) => {
               className={`base base-second ${state.runners.second ? "occupied" : ""}`}
               onClick={() => toggleRunner("second")}
             />
+            {state.runners.second && state.runnerIdentity?.second && (() => {
+              const p = getPlayerById(state, state.runnerIdentity.second);
+              return p ? <span className="runner-label runner-label-second">#{p.number} {p.lastName || p.name}</span> : null;
+            })()}
             <div
               className={`base base-third ${state.runners.third ? "occupied" : ""}`}
               onClick={() => toggleRunner("third")}
             />
+            {state.runners.third && state.runnerIdentity?.third && (() => {
+              const p = getPlayerById(state, state.runnerIdentity.third);
+              return p ? <span className="runner-label runner-label-third">#{p.number} {p.lastName || p.name}</span> : null;
+            })()}
             <div
               className={`base base-first ${state.runners.first ? "occupied" : ""}`}
               onClick={() => toggleRunner("first")}
             />
+            {state.runners.first && state.runnerIdentity?.first && (() => {
+              const p = getPlayerById(state, state.runnerIdentity.first);
+              return p ? <span className="runner-label runner-label-first">#{p.number} {p.lastName || p.name}</span> : null;
+            })()}
             <div className="base base-home" />
           </div>
         </div>

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,0 +1,39 @@
+import { useLocation, useNavigate } from "react-router-dom";
+
+const TABS = [
+  { path: "/console", label: "Score", icon: "⚾" },
+  { path: "/stats", label: "Stats", icon: "📊" },
+  { path: "/settings", label: "Settings", icon: "⚙" },
+];
+
+// Hide nav bar on these route prefixes
+const HIDDEN_PREFIXES = ["/manual", "/overlay", "/login"];
+
+const NavBar = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // Hide on scoring, overlay, and login pages
+  const shouldHide = HIDDEN_PREFIXES.some((p) => location.pathname.startsWith(p));
+  if (shouldHide) return null;
+
+  const activeTab = TABS.find((t) => location.pathname.startsWith(t.path))
+    || TABS[0]; // default to Score tab
+
+  return (
+    <nav className="nav-bar">
+      {TABS.map((tab) => (
+        <button
+          key={tab.path}
+          className={`nav-tab ${activeTab.path === tab.path ? "active" : ""}`}
+          onClick={() => navigate(tab.path)}
+        >
+          <span className="nav-icon">{tab.icon}</span>
+          <span className="nav-label">{tab.label}</span>
+        </button>
+      ))}
+    </nav>
+  );
+};
+
+export default NavBar;

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getFirestore, doc, getDoc, updateDoc } from "firebase/firestore";
+import { getAuth, signOut } from "firebase/auth";
+import { useAuth } from "../contexts/AuthContext";
+import { callSetCustomClaims } from "../utils/authUtils";
+
+const SettingsPage = () => {
+  const { user, tenantId, loading } = useAuth();
+  const navigate = useNavigate();
+  const [memberships, setMemberships] = useState({});
+  const [activeTenant, setActiveTenant] = useState(tenantId);
+  const [updating, setUpdating] = useState(false);
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      if (!user) return;
+      const db = getFirestore();
+      const userRef = doc(db, "users", user.uid);
+      try {
+        const userSnap = await getDoc(userRef);
+        if (userSnap.exists()) {
+          const data = userSnap.data();
+          setMemberships(data.memberships || {});
+          setActiveTenant(data.activeTenant);
+        }
+      } catch (err) {
+        console.error("Error fetching user data:", err);
+      }
+    };
+    fetchUserData();
+  }, [user]);
+
+  const handleSwitchTeam = async (newTenantId) => {
+    if (!user || newTenantId === activeTenant) return;
+    setUpdating(true);
+    const db = getFirestore();
+    const userRef = doc(db, "users", user.uid);
+    await updateDoc(userRef, { activeTenant: newTenantId });
+    await callSetCustomClaims();
+    setActiveTenant(newTenantId);
+    setUpdating(false);
+  };
+
+  const handleSignOut = async () => {
+    const auth = getAuth();
+    await signOut(auth);
+    navigate("/login");
+  };
+
+  if (loading) return <div className="loading-page">Loading...</div>;
+  if (!user) {
+    navigate("/login");
+    return null;
+  }
+
+  const currentRoles = Array.isArray(memberships?.[activeTenant]?.roles)
+    ? memberships[activeTenant].roles.join(", ")
+    : "none";
+
+  return (
+    <div className="settings-page">
+      <div className="page-header">
+        <h2>Settings</h2>
+      </div>
+
+      <div className="card" style={{ marginTop: 12 }}>
+        <h3>Profile</h3>
+        <p className="profile-info"><strong>Email:</strong> {user?.email}</p>
+        <p className="profile-info"><strong>Role(s):</strong> {currentRoles}</p>
+        <p className="profile-info"><strong>Active Team:</strong> {activeTenant}</p>
+      </div>
+
+      {Object.keys(memberships).length > 1 && (
+        <div className="card">
+          <h3>Switch Team</h3>
+          <ul className="team-list">
+            {Object.entries(memberships).map(([teamId, info]) => (
+              <li key={teamId}>
+                <button
+                  disabled={updating || teamId === activeTenant}
+                  onClick={() => handleSwitchTeam(teamId)}
+                >
+                  {teamId} ({Array.isArray(info.roles) ? info.roles.join(", ") : "no roles"})
+                  {teamId === activeTenant ? " (active)" : ""}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="card">
+        <h3>App</h3>
+        <p className="profile-info"><strong>Version:</strong> 1.3.0</p>
+        <button
+          className="btn-danger btn-small"
+          onClick={handleSignOut}
+          style={{ marginTop: 12 }}
+        >
+          Sign Out
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/src/pages/StatsPage.jsx
+++ b/src/pages/StatsPage.jsx
@@ -1,0 +1,30 @@
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+
+const StatsPage = () => {
+  const { user, loading } = useAuth();
+  const navigate = useNavigate();
+
+  if (loading) return <div className="loading-page">Loading...</div>;
+  if (!user) {
+    navigate("/login");
+    return null;
+  }
+
+  return (
+    <div className="stats-page">
+      <div className="page-header">
+        <h2>Statistics</h2>
+      </div>
+      <div className="card" style={{ textAlign: "center", padding: "48px 24px" }}>
+        <p style={{ fontSize: "2rem", marginBottom: 12 }}>📊</p>
+        <h3>Coming Soon</h3>
+        <p style={{ color: "var(--text-secondary)", marginTop: 8 }}>
+          Player and team statistics across seasons and tournaments will be available here.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default StatsPage;

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,8 +1,11 @@
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, RouterProvider, Outlet } from "react-router-dom";
 import Console from "./components/Console";
 import ManualScoringPage from "./pages/ManualScoringPage";
 import LoginPage from "./pages/LoginPage";
 import OverlayFromFigma from "./pages/OverlayFromFigma";
+import StatsPage from "./pages/StatsPage";
+import SettingsPage from "./pages/SettingsPage";
+import NavBar from "./components/NavBar";
 
 const ErrorFallback = () => (
   <div style={{ padding: "2rem" }}>
@@ -11,32 +14,28 @@ const ErrorFallback = () => (
   </div>
 );
 
+/** Layout wrapper — renders NavBar below page content */
+const AppLayout = () => (
+  <>
+    <Outlet />
+    <NavBar />
+  </>
+);
+
 const router = createBrowserRouter([
   {
-    path: "/",
-    element: <Console />,
-    errorElement: <ErrorFallback />
+    element: <AppLayout />,
+    errorElement: <ErrorFallback />,
+    children: [
+      { path: "/", element: <Console /> },
+      { path: "/console", element: <Console /> },
+      { path: "/stats", element: <StatsPage /> },
+      { path: "/settings", element: <SettingsPage /> },
+      { path: "/manual/:gameId", element: <ManualScoringPage /> },
+      { path: "/overlay/:gameId", element: <OverlayFromFigma showGrid={false} /> },
+      { path: "/login", element: <LoginPage /> },
+    ],
   },
-  {
-    path: "/console",
-    element: <Console />,
-    errorElement: <ErrorFallback />
-  },
-  {
-    path: "/manual/:gameId",
-    element: <ManualScoringPage />,
-    errorElement: <ErrorFallback />
-  },
-  {
-    path: "/overlay/:gameId",
-    element: <OverlayFromFigma showGrid={false} />,
-    errorElement: <ErrorFallback />
-  },
-  {
-    path: "/login",
-    element: <LoginPage />,
-    errorElement: <ErrorFallback />
-  }
 ]);
 
 const AppRouter = () => <RouterProvider router={router} />;


### PR DESCRIPTION
## Summary
- **Bottom tab bar:** Score / Stats / Settings tabs, hidden during live scoring & overlay
- **Settings page:** Profile info, team switching, sign out, app version (moved from Console)
- **Stats page:** Placeholder for upcoming statistics
- **Player names on diamond:** Occupied bases show `#number LastName` labels
- Router restructured with layout route for NavBar context

## Test plan
- [x] 203 tests pass
- [x] Clean production build
- [x] Nav bar hidden on scoring page ✓
- [x] Nav bar hidden on login page ✓
- [ ] Manual test: navigate between tabs
- [ ] Manual test: runner names appear with rosters loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)