### PR TITLE
Full field view with fielder positions + BSO under scoreboard

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -376,15 +376,15 @@ label input, label select {
   cursor: pointer;
 }
 
-/* ── BSO + Diamond side-by-side row ── */
-.bso-diamond-row {
+/* ── BSO compact row under scoreboard ── */
+.bso-row {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 16px;
-  padding: 8px 16px;
+  padding: 6px 16px;
   background: var(--bg-secondary);
-  margin-bottom: 8px;
+  border-bottom: 1px solid var(--border-color);
 }
 
 /* ── Scoring main grid (controls + sidebar) ── */
@@ -566,7 +566,7 @@ label input, label select {
   to { opacity: 1; transform: translateY(0); }
 }
 
-/* BSO (Balls/Strikes/Outs) section */
+/* BSO (Balls/Strikes/Outs) section — legacy wrapper, kept for compat */
 .bso-section {
   display: flex;
   flex-direction: column;
@@ -1574,6 +1574,22 @@ label input, label select {
   transform: none;
 }
 
+/* === Baseball Field View === */
+.field-container {
+  padding: 4px 8px 8px;
+  background: var(--bg-secondary);
+  margin-bottom: 8px;
+}
+
+.baseball-field-svg {
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+  border-radius: 8px;
+}
+
 /* === Responsive === */
 
 /* ── Tablet (600px+) ── */
@@ -1618,31 +1634,24 @@ label input, label select {
     grid-template-columns: 1fr 1fr 1fr 1fr;
   }
 
-  /* Larger diamond on tablet */
-  .diamond {
-    width: 120px;
-    height: 120px;
-  }
-
-  .diamond .base {
-    width: 30px;
-    height: 30px;
-  }
-
-  .diamond .base-second { margin-left: -15px; }
-  .diamond .base-third { margin-top: -15px; }
-  .diamond .base-first { margin-top: -15px; }
-  .diamond .base-home { margin-left: -15px; }
-
   /* BSO dots slightly larger */
   .bso-dot {
     width: 22px;
     height: 22px;
   }
 
-  .bso-diamond-row {
-    gap: 32px;
-    padding: 12px 24px;
+  .bso-row {
+    gap: 24px;
+    padding: 8px 24px;
+  }
+
+  /* Constrain field size on tablet */
+  .field-container {
+    padding: 8px 16px 12px;
+  }
+
+  .baseball-field-svg {
+    max-width: 400px;
   }
 
   /* Two-column layout: scoring controls + sidebar */
@@ -1677,24 +1686,6 @@ label input, label select {
     padding: 0 16px 12px;
   }
 
-  /* Larger runner labels on tablet */
-  .runner-label {
-    font-size: 11px;
-    max-width: 90px;
-  }
-
-  .runner-label-second {
-    top: 32px;
-  }
-
-  .runner-label-third {
-    top: calc(50% + 18px);
-  }
-
-  .runner-label-first {
-    top: calc(50% + 18px);
-  }
-
   /* Nav bar centered on tablet */
   .nav-bar {
     max-width: 768px;
@@ -1713,9 +1704,8 @@ label input, label select {
     grid-template-columns: 1fr 340px;
   }
 
-  .bso-diamond-row {
-    gap: 48px;
-    padding: 16px 32px;
+  .baseball-field-svg {
+    max-width: 450px;
   }
 
   .nav-bar {

--- a/src/components/BaseballField.jsx
+++ b/src/components/BaseballField.jsx
@@ -1,0 +1,211 @@
+/**
+ * BaseballField — Full field view with fielder positions and interactive bases.
+ *
+ * Renders an SVG baseball field (outfield arc, foul lines, infield diamond)
+ * with 9 fielder position markers and tappable bases for runner toggles.
+ */
+import { getPlayerById } from "../utils/rosterHelpers";
+
+// Standard fielder positions in SVG coordinates (viewBox 0 0 300 300)
+// Field is oriented with home plate at bottom-center
+const FIELDER_COORDS = {
+  P:  { x: 150, y: 185 },
+  C:  { x: 150, y: 265 },
+  "1B": { x: 215, y: 185 },
+  "2B": { x: 175, y: 150 },
+  SS: { x: 125, y: 150 },
+  "3B": { x: 85, y: 185 },
+  LF: { x: 55, y: 95 },
+  CF: { x: 150, y: 55 },
+  RF: { x: 245, y: 95 },
+};
+
+// Base positions in SVG coordinates
+const BASE_COORDS = {
+  first:  { x: 200, y: 200 },
+  second: { x: 150, y: 155 },
+  third:  { x: 100, y: 200 },
+  home:   { x: 150, y: 245 },
+};
+
+const BASE_SIZE = 14;
+
+function FielderMarker({ position, player }) {
+  const coord = FIELDER_COORDS[position];
+  if (!coord) return null;
+
+  const label = player
+    ? `#${player.number || ""}`
+    : position;
+  const nameLine = player
+    ? (player.lastName || player.name || "").slice(0, 8)
+    : "";
+
+  return (
+    <g className="fielder-marker">
+      <circle cx={coord.x} cy={coord.y} r={13} fill="rgba(74, 144, 217, 0.25)" stroke="#4a90d9" strokeWidth={1.5} />
+      <text x={coord.x} y={coord.y + 1} textAnchor="middle" dominantBaseline="central"
+        fontSize={player ? 9 : 10} fontWeight="700" fill="#4a90d9">
+        {label}
+      </text>
+      {nameLine && (
+        <text x={coord.x} y={coord.y + 16} textAnchor="middle"
+          fontSize={7.5} fontWeight="500" fill="#a0a0b0">
+          {nameLine}
+        </text>
+      )}
+    </g>
+  );
+}
+
+function BaseDiamond({ base, occupied, runnerLabel, onToggle }) {
+  const coord = BASE_COORDS[base];
+  const isHome = base === "home";
+  const half = BASE_SIZE / 2;
+
+  // Diamond shape rotated 45deg
+  const points = `${coord.x},${coord.y - half} ${coord.x + half},${coord.y} ${coord.x},${coord.y + half} ${coord.x - half},${coord.y}`;
+
+  return (
+    <g>
+      <polygon
+        points={points}
+        fill={occupied ? "#f1c40f" : "transparent"}
+        stroke={isHome ? "#2a2a4a" : (occupied ? "#f1c40f" : "#a0a0b0")}
+        strokeWidth={2}
+        style={{ cursor: isHome ? "default" : "pointer" }}
+        onClick={isHome ? undefined : onToggle}
+      />
+      {/* Touch target — larger invisible hit area for mobile */}
+      {!isHome && (
+        <circle
+          cx={coord.x} cy={coord.y} r={20}
+          fill="transparent"
+          style={{ cursor: "pointer" }}
+          onClick={onToggle}
+        />
+      )}
+      {occupied && runnerLabel && (
+        <text
+          x={base === "third" ? coord.x - 18 : base === "first" ? coord.x + 18 : coord.x}
+          y={base === "second" ? coord.y - 16 : coord.y + 20}
+          textAnchor={base === "third" ? "end" : base === "first" ? "start" : "middle"}
+          fontSize={8} fontWeight="600" fill="#f1c40f"
+          style={{ pointerEvents: "none" }}
+        >
+          {runnerLabel}
+        </text>
+      )}
+    </g>
+  );
+}
+
+const BaseballField = ({ state, onToggleRunner }) => {
+  // Fielding team roster (opposite of batting team)
+  const fieldingRoster = state.isTop ? state.homeRoster : state.awayRoster;
+
+  // Build a position → player map from the fielding roster
+  const fielderMap = {};
+  if (fieldingRoster) {
+    for (const player of fieldingRoster) {
+      if (player.position && FIELDER_COORDS[player.position]) {
+        fielderMap[player.position] = player;
+      }
+      // FLEX fields at their position but could be any fielding pos
+      // Already handled above since FLEX isn't in FIELDER_COORDS
+    }
+  }
+
+  // Runner labels
+  const getRunnerLabel = (base) => {
+    if (!state.runners[base] || !state.runnerIdentity?.[base]) return null;
+    const p = getPlayerById(state, state.runnerIdentity[base]);
+    if (!p) return null;
+    return `#${p.number} ${p.lastName || p.name}`;
+  };
+
+  return (
+    <div className="field-container">
+      <svg viewBox="0 0 300 300" className="baseball-field-svg">
+        {/* Grass background */}
+        <rect x="0" y="0" width="300" height="300" fill="#1a3a1a" rx="8" />
+
+        {/* Outfield arc */}
+        <path
+          d="M 10,245 Q 10,20 150,20 Q 290,20 290,245"
+          fill="#1e4a1e"
+          stroke="#2a5a2a"
+          strokeWidth={2}
+        />
+
+        {/* Infield dirt */}
+        <path
+          d="M 100,200 L 150,155 L 200,200 L 150,245 Z"
+          fill="#3a2a1a"
+          stroke="#5a4a3a"
+          strokeWidth={1}
+        />
+
+        {/* Infield diamond outline */}
+        <path
+          d="M 100,200 L 150,155 L 200,200 L 150,245 Z"
+          fill="none"
+          stroke="#6a5a4a"
+          strokeWidth={1.5}
+        />
+
+        {/* Pitcher's mound */}
+        <circle cx={150} cy={195} r={5} fill="#4a3a2a" stroke="#6a5a4a" strokeWidth={1} />
+
+        {/* Foul lines */}
+        <line x1="150" y1="245" x2="10" y2="95" stroke="#6a5a4a" strokeWidth={1} strokeDasharray="4,4" />
+        <line x1="150" y1="245" x2="290" y2="95" stroke="#6a5a4a" strokeWidth={1} strokeDasharray="4,4" />
+
+        {/* Base paths (connecting lines) */}
+        <line x1={BASE_COORDS.home.x} y1={BASE_COORDS.home.y} x2={BASE_COORDS.first.x} y2={BASE_COORDS.first.y}
+          stroke="#6a5a4a" strokeWidth={1.5} />
+        <line x1={BASE_COORDS.first.x} y1={BASE_COORDS.first.y} x2={BASE_COORDS.second.x} y2={BASE_COORDS.second.y}
+          stroke="#6a5a4a" strokeWidth={1.5} />
+        <line x1={BASE_COORDS.second.x} y1={BASE_COORDS.second.y} x2={BASE_COORDS.third.x} y2={BASE_COORDS.third.y}
+          stroke="#6a5a4a" strokeWidth={1.5} />
+        <line x1={BASE_COORDS.third.x} y1={BASE_COORDS.third.y} x2={BASE_COORDS.home.x} y2={BASE_COORDS.home.y}
+          stroke="#6a5a4a" strokeWidth={1.5} />
+
+        {/* Fielder position markers */}
+        {Object.keys(FIELDER_COORDS).map((pos) => (
+          <FielderMarker
+            key={pos}
+            position={pos}
+            player={fielderMap[pos] || null}
+          />
+        ))}
+
+        {/* Bases (interactive) */}
+        <BaseDiamond
+          base="second"
+          occupied={state.runners.second}
+          runnerLabel={getRunnerLabel("second")}
+          onToggle={() => onToggleRunner("second")}
+        />
+        <BaseDiamond
+          base="third"
+          occupied={state.runners.third}
+          runnerLabel={getRunnerLabel("third")}
+          onToggle={() => onToggleRunner("third")}
+        />
+        <BaseDiamond
+          base="first"
+          occupied={state.runners.first}
+          runnerLabel={getRunnerLabel("first")}
+          onToggle={() => onToggleRunner("first")}
+        />
+        <BaseDiamond
+          base="home"
+          occupied={false}
+        />
+      </svg>
+    </div>
+  );
+};
+
+export default BaseballField;

--- a/src/components/ManualScoreController.jsx
+++ b/src/components/ManualScoreController.jsx
@@ -10,6 +10,7 @@ import GameStats from "./GameStats";
 import FielderPickerModal from "./FielderPickerModal";
 import RunnerPickerModal from "./RunnerPickerModal";
 import LineupEditor from "./LineupEditor";
+import BaseballField from "./BaseballField";
 
 const ManualScoreController = ({ gameId }) => {
   // ─── Game state (scoring engine is single source of truth) ───
@@ -432,65 +433,36 @@ const ManualScoreController = ({ gameId }) => {
         </div>
       )}
 
-      {/* ── BSO + Diamond side-by-side ── */}
-      <div className="bso-diamond-row">
-        <div className="bso-section">
-          <div className="bso-group">
-            <div className="bso-label">B</div>
-            <div className="bso-dots">
-              {[0, 1, 2, 3].map(i => (
-                <div key={i} className={`bso-dot ball ${i < state.balls ? "active" : ""}`} />
-              ))}
-            </div>
-          </div>
-          <div className="bso-group">
-            <div className="bso-label">S</div>
-            <div className="bso-dots">
-              {[0, 1, 2].map(i => (
-                <div key={i} className={`bso-dot strike ${i < state.strikes ? "active" : ""}`} />
-              ))}
-            </div>
-          </div>
-          <div className="bso-group">
-            <div className="bso-label">O</div>
-            <div className="bso-dots">
-              {[0, 1, 2].map(i => (
-                <div key={i} className={`bso-dot out ${i < state.outs ? "active" : ""}`} />
-              ))}
-            </div>
+      {/* ── BSO compact row under scoreboard ── */}
+      <div className="bso-row">
+        <div className="bso-group">
+          <div className="bso-label">B</div>
+          <div className="bso-dots">
+            {[0, 1, 2, 3].map(i => (
+              <div key={i} className={`bso-dot ball ${i < state.balls ? "active" : ""}`} />
+            ))}
           </div>
         </div>
-
-        <div className="diamond-container">
-          <div className="diamond">
-            <div
-              className={`base base-second ${state.runners.second ? "occupied" : ""}`}
-              onClick={() => toggleRunner("second")}
-            />
-            {state.runners.second && state.runnerIdentity?.second && (() => {
-              const p = getPlayerById(state, state.runnerIdentity.second);
-              return p ? <span className="runner-label runner-label-second">#{p.number} {p.lastName || p.name}</span> : null;
-            })()}
-            <div
-              className={`base base-third ${state.runners.third ? "occupied" : ""}`}
-              onClick={() => toggleRunner("third")}
-            />
-            {state.runners.third && state.runnerIdentity?.third && (() => {
-              const p = getPlayerById(state, state.runnerIdentity.third);
-              return p ? <span className="runner-label runner-label-third">#{p.number} {p.lastName || p.name}</span> : null;
-            })()}
-            <div
-              className={`base base-first ${state.runners.first ? "occupied" : ""}`}
-              onClick={() => toggleRunner("first")}
-            />
-            {state.runners.first && state.runnerIdentity?.first && (() => {
-              const p = getPlayerById(state, state.runnerIdentity.first);
-              return p ? <span className="runner-label runner-label-first">#{p.number} {p.lastName || p.name}</span> : null;
-            })()}
-            <div className="base base-home" />
+        <div className="bso-group">
+          <div className="bso-label">S</div>
+          <div className="bso-dots">
+            {[0, 1, 2].map(i => (
+              <div key={i} className={`bso-dot strike ${i < state.strikes ? "active" : ""}`} />
+            ))}
+          </div>
+        </div>
+        <div className="bso-group">
+          <div className="bso-label">O</div>
+          <div className="bso-dots">
+            {[0, 1, 2].map(i => (
+              <div key={i} className={`bso-dot out ${i < state.outs ? "active" : ""}`} />
+            ))}
           </div>
         </div>
       </div>
+
+      {/* ── Full baseball field view ── */}
+      <BaseballField state={state} onToggleRunner={toggleRunner} />
 
       {/* ── Scoring controls + sidebar wrapper ── */}
       <div className="scoring-main">


### PR DESCRIPTION
## Summary
- Replace diamond-only view with full SVG baseball field (outfield arc, foul lines, infield, pitcher's mound, base paths)
- Add 9 fielder position markers (P, C, 1B, 2B, SS, 3B, LF, CF, RF) showing player number/name from the fielding team's lineup
- Move BSO indicators into a compact horizontal row directly under the scoreboard (`B ●●○○  S ●●○  O ●○○`)
- Interactive bases remain tappable with 40px+ touch targets; field scales to fill phone width

Closes #31

## Test plan
- [ ] Verify field renders on phone — fills width, all 9 positions visible
- [ ] Verify fielder markers show player info when lineup is loaded
- [ ] Verify BSO row displays correctly under scoreboard with accurate counts
- [ ] Tap bases to toggle runners on/off — confirm runner labels appear
- [ ] Check tablet/desktop — field constrained to 400-450px max
- [ ] Run `npm test` — all 203 tests pass
- [ ] Run `npm run build` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)